### PR TITLE
AI update: context menu changes, all target selection types

### DIFF
--- a/DataPad.a4dbbf.ttslua
+++ b/DataPad.a4dbbf.ttslua
@@ -2786,6 +2786,7 @@ function idSpawner(idTable)
         fList.Pilots[k]['Docking'] = masterShipDB[Ship]['Docking']
         fList.Pilots[k]['Data'] = {}
         fList.Pilots[k]['Data']['shipId'] = Ship
+        fList.Pilots[k]['Data']['initiative'] = masterPilotDB[v].init
         fList.Pilots[k]['Data']['moveSet'] = masterShipDB[Ship]['moveSet']
         fList.Pilots[k]['Data']['arcs'] = masterShipDB[Ship]['arcs']
         fList.Pilots[k]['Data']['actSet'] = masterPilotDB[v]['actSet']

--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -219,6 +219,8 @@ XW_cmd.Process = function(obj, cmd)
         DialModule.PerformAction(obj, cmd)
     elseif type == 'bombDrop' then
         BombModule.ToggleDrop(obj, cmd)
+    elseif type == 'AI' then
+        AIModule.EnableAI(obj, cmd)
     end
     obj.setDescription('')
     return true
@@ -275,7 +277,7 @@ XW_cmd.AddCommand('a[12]', 'actionMove')        -- Adjusts
 --XW_cmd.AddCommand('vr[rle][fb]', 'actionMove')  -- StarViper Mk.II rolls
 
 -- AI Module:
-enable_AI = false
+test_AI = false
 AIModule = {}
 
 -- 2000mm is the length between opposite corners of an epic table.
@@ -298,6 +300,11 @@ AIModule.current_move.Reset = function()
     AIModule.current_move.obstacle = false
     AIModule.current_move.stress_count = 0
     AIModule.current_move.is_ionised = false
+end
+
+-- Description function to add the AI functions to a ship
+AIModule.EnableAI = function(ship, command)
+    ship.AddContextMenuItem("AI maneuver", function(argument) Global.call("PerformAIManeuver", {ship=ship}) end, false)
 end
 
 -- Sanity check, make sure that all the moves for this ship are actually
@@ -815,6 +822,9 @@ AIModule.IsIonised = function(ship)
 
     return false
 end
+
+-- Possible commands supported by the AI module
+XW_cmd.AddCommand('ai', 'AI')   -- Enables the AI on the selected ship
 
 
 ArcCheck = {}
@@ -5168,7 +5178,7 @@ function initContextMenu()
         end
     end
 
-    if Global.getVar('enable_AI') then
+    if Global.getVar('test_AI') then
         self.AddContextMenuItem("AI maneuver", function(argument) Global.call("PerformAIManeuver", {ship=self}) end, false)
     end
 end

--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -327,11 +327,16 @@ AIModule.ValidateMoveTables = function(ship)
 end
 
 -- Only choose ships that are in arc and between ranges 1-3
-AIModule.FilterForAITargetting = function(el)
+AIModule.FilterInArc = function(el)
     if el['in_arc'] == false then
         return false
     end
 
+    return true;
+end
+
+-- Only choose ships that are between range one and three
+AIModule.FilterInRange = function(el)
     if el['closest'].range < 1 or el['closest'].range > 3 then
         return false
     end
@@ -358,13 +363,19 @@ function PerformAIManeuver(args)
     AIModule.PerformManeuver(ship)
 end
 
+AIModule.GetSortedTargetsInArc = function(ship, arc)
+    local targets = ArcCheck.GetTargetsInRelationToArc(ship, arc or 'front')
+    targets = table.sieve(targets, AIModule.FilterInArc)
+    targets = table.sieve(targets, AIModule.FilterInRange)
+    table.sort(targets, AIModule.SortTargetsByAIDesirability)
+    return targets
+end
+
 -- Target selection functions. These take a ship, and return a target ship
 AIModule.TargetSelectionFunctions = {}
 AIModule.TargetSelectionFunctions['ClosestInArc'] = function(ship)
-    local targets = ArcCheck.GetTargetsInRelationToArc(ship, 'front')
-    targets = table.sieve(targets, AIModule.FilterForAITargetting)
-    --TODO: Replace this with just a simple distance check. It's faster as it's O(n) not O(log(n))
-    table.sort(targets, AIModule.SortTargetsByAIDesirability)
+    local targets = AIModule.GetSortedTargetsInArc(ship)
+
     -- Get the first ship as it's already been sorted by distance
     for i, target in pairs(targets) do
         return target['ship']
@@ -375,17 +386,59 @@ end
 
 AIModule.TargetSelectionFunctions['Closest'] = function(ship)
     local potential_targets = ArcCheck.GetPotentialTargets(ship, AIModule.max_distance)
+
     local closest_distance = nil
     local closest_target = nil
     for i, target in pairs(potential_targets) do
         local distance = Vect.Length(ship.getPosition() - target.GetPosition())
-        if closest_distance == nil or  distance < closest_distance then
+        if closest_distance == nil or distance < closest_distance then
             closest_distance = distance
             closest_target = target
         end
     end
 
     return closest_target
+end
+
+AIModule.TargetSelectionFunctions['LockedInRange'] = function(ship)
+    local potential_targets = AIModule.GetSortedTargetsInArc(ship, 'all')
+    potential_targets = table.sieve(potential_targets, AIModule.FilterInRange)
+
+    local closest_distance = nil
+    local closest_target = nil
+    for i, target in pairs(potential_targets) do
+        -- Is this ship locked by us?
+        local is_target_locked = false
+        ship_tokens = TokenModule.GetShipTokens(target['ship'])
+        for j, token in pairs(ship_tokens) do
+            is_target_locked = token.GetName() == ship.GetName()
+        end
+
+        if is_target_locked then
+            local distance = Vect.Length(ship.getPosition() - target['ship'].GetPosition())
+            if closest_distance == nil or distance < closest_distance then
+                closest_distance = distance
+                closest_target = target['ship']
+            end
+        end
+    end
+
+    return closest_target
+end
+
+AIModule.TargetSelectionFunctions['ClosestInArcLowerInitiative'] = function(ship)
+    local initiative = ship.getTable('Data')['initiative']
+    local targets = AIModule.GetSortedTargetsInArc(ship)
+
+    -- Get the first ship with a lower initiative as it's already been sorted by
+    -- distance.
+    for i, target in pairs(targets) do
+        if (target['ship'].getTable('Data')['initiative'] < initiative) then
+            return target['ship']
+        end
+    end
+
+    return nil
 end
 
 AIModule.PerformManeuver = function(ship)
@@ -1057,6 +1110,8 @@ ArcCheck.GetTargetsInRelationToArc = function(ship, arctype)
         arc_parts = {"front", "back"}
     elseif arctype == "leftright" then
         arc_parts = {"left", "right"}
+    elseif arctype == "all" then
+        arc_parts = {"front", "back", "left", "right"}
     end
     ship.setLock(true)
     local shipSize = ship.getTable("Data").Size or 'small'

--- a/TTS_xwing/src/BehaviourDB.ttslua
+++ b/TTS_xwing/src/BehaviourDB.ttslua
@@ -197,8 +197,7 @@ BehaviourDB.rule_sets[1].ships[41].move_table = {
 
 -- TIE Advanced x1
 BehaviourDB.rule_sets[1].ships[13] = {}
--- Need to add: Locked enemy within range 3, nearest enemy with lower initiative
-BehaviourDB.rule_sets[1].ships[13].target_selection = {[1]='ClosestInArc', [2]='Closest'}
+BehaviourDB.rule_sets[1].ships[13].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
 BehaviourDB.rule_sets[1].ships[13].move_table = {
     ['bullseye'] = {
         ['near'] = {[1] = 'k4', [3] = 's1', [5] = 's2'},
@@ -234,8 +233,7 @@ BehaviourDB.rule_sets[1].ships[13].move_table = {
 
 -- TIE/sa Bomber
 BehaviourDB.rule_sets[1].ships[19] = {}
--- Need to add: Locked enemy within range 3
-BehaviourDB.rule_sets[1].ships[19].target_selection = {[1]='ClosestInArc', [2]='Closest'}
+BehaviourDB.rule_sets[1].ships[19].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
 BehaviourDB.rule_sets[1].ships[19].move_table = {
     ['bullseye'] = {
         ['near'] = {[1] = 'k5', [3] = 's1', [5] = 's2'},
@@ -271,8 +269,7 @@ BehaviourDB.rule_sets[1].ships[19].move_table = {
 
 -- TIE/de Defender
 BehaviourDB.rule_sets[1].ships[18] = {}
--- Need to add: Locked enemy within range 3, nearest enemy with lower initiative
-BehaviourDB.rule_sets[1].ships[18].target_selection = {[1]='ClosestInArc', [2]='Closest'}
+BehaviourDB.rule_sets[1].ships[18].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
 BehaviourDB.rule_sets[1].ships[18].move_table = {
     ['bullseye'] = {
         ['near'] = {[1] = 'k4', [3] = 'bl1', [4] = 'br1', [5] = 's2'},
@@ -381,8 +378,7 @@ BehaviourDB.rule_sets[1].ships[26].move_table = {
 
 -- VT-49 Decimator
 BehaviourDB.rule_sets[1].ships[28] = {}
--- Need to add nearest enem in range 3 (no arc)
-BehaviourDB.rule_sets[1].ships[28].target_selection = {[1]='ClosestInArc', [2]='Closest'}
+BehaviourDB.rule_sets[1].ships[28].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
 BehaviourDB.rule_sets[1].ships[28].move_table = {
     ['bullseye'] = {
         ['near'] = {[1] = 'tl2', [3] = 'tr2', [5] = 'tl3', [6] = 'tr3'},


### PR DESCRIPTION
This PR includes two features:

The first is moving the AI enabling from requiring a code change to a description command. Entering the description of "ai" on a ship will enable the "AI maneuver" context item. This means it can be used by regular players without requiring knowledge of editing the codebase.

The second is the two remaining target selection types needed for the Imperial roster. One has required a change to Datapad so the AI module can access each pilot's initiative. The second relies on the target lock naming system - this doesn't seem robust as it relies on the ship's name rather than something unique like the ship's GUID. I didn't want to make that change as it seemed fairly large, but if that's okay then I'm happy to make it.