### PR TITLE
Turrets, some AI fixes

### DIFF
--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -1070,29 +1070,28 @@ AIModule.AttemptAction = function(ship, target, action_definition)
             if AIModule.move_actions[action] ~= nil then
                 action_includes_move_component = true
 
-                -- This action is a move action, so expand our current set of
-                -- possible action probes further.
-                if initial_move == true then
-                    probe_sets[set_index] = table.join(probe_sets[set_index], AIModule.ExpandActionProbe(ship, initial_probe, AIModule.move_actions[action]))
-                    initial_move = false
-                else
-                    new_probes = {}
-                    for _, probe in pairs(probe_sets[set_index]) do
-                        new_probes = table.join(new_probes, AIModule.ExpandActionProbe(ship, probe, AIModule.move_actions[action]))
-                    end
-
-                    probe_sets[set_index] = table.join(probe_sets[set_index], new_probes)
-                end
-
-                -- Set the move difficulty and the set index on each probe.
                 local move_difficulty = 'w'
                 if stress then
                     move_difficulty = 'r'
                 end
 
+                -- This action is a move action, so expand our current set of
+                -- possible action probes further.
+                if initial_move == true then
+                    probe_sets[set_index] = table.join(probe_sets[set_index], AIModule.ExpandActionProbe(ship, initial_probe, AIModule.move_actions[action], move_difficulty))
+                    initial_move = false
+                else
+                    new_probes = {}
+                    for _, probe in pairs(probe_sets[set_index]) do
+                        new_probes = table.join(new_probes, AIModule.ExpandActionProbe(ship, probe, AIModule.move_actions[action], move_difficulty))
+                    end
+
+                    probe_sets[set_index] = table.join(probe_sets[set_index], new_probes)
+                end
+
+                -- Set the set index on each probe.
                 for _, probe in pairs(probe_sets[set_index]) do
                     probe.set_index = set_index
-                    probe.difficulty = move_difficulty
                 end
             else
                 -- There's one instance that we skip the action - we don't take
@@ -1310,7 +1309,7 @@ end
 
 -- This function takes an existing probe, and appends all possible moves in
 -- a move list onto it, returning a list of those that are possible.
-AIModule.ExpandActionProbe = function(ship, probe, moves)
+AIModule.ExpandActionProbe = function(ship, probe, moves, difficulty)
     local possible_probes = {}
 
     local probe_name = ''
@@ -1328,6 +1327,7 @@ AIModule.ExpandActionProbe = function(ship, probe, moves)
         new_probe = AIModule.current_move.probes[new_probe_name]
         if new_probe ~= nil then
             if new_probe.possible == true then
+                new_probe.difficulty = difficulty
                 table.insert(possible_probes, new_probe)
             end
         else
@@ -1345,6 +1345,7 @@ AIModule.ExpandActionProbe = function(ship, probe, moves)
                 new_probe.parent = probe
                 new_probe.action_targets = {}
                 new_probe.possible = true
+                new_probe.difficulty = difficulty
                 new_probe.position = probe_data.finalPosRot['pos']
                 new_probe.rotation = probe_data.finalPosRot['rot']
                 table.insert(possible_probes, new_probe)

--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -6012,6 +6012,24 @@ function onObjectSpawned(obj)
     obj.hide_when_face_down = false
 end
 
+-- Positions for arc indicator tokens around the ship mounts
+-- Used so arc indicators can snap to the relevant positions
+mountPositions = {
+    ['small'] = {
+        ['main'] = {0, 0}
+    },
+    ['medium'] = {
+        ['main'] = {0, 0}
+    },
+    ['large'] = {
+        ['main'] = {0, 0}
+    },
+    ['huge'] = {
+        ['front'] = {0, -2.63},
+        ['rear'] = {0, 2.63}
+    }
+}
+
 -- Save and load ship data lua scriptState
 saveAndLoadShipStateLua = [[
 
@@ -6113,6 +6131,27 @@ function RemoveArcIndicator(args)
     end
 end
 
+function GetAvailableMountPositions(args)
+    local mount_positions = Global.getTable('mountPositions')[self.getTable("Data").Size]
+
+    for location, _ in pairs(assigned_arc_indicators) do
+        mount_positions[location] = nil
+    end
+
+    local ship_position = self.getPosition()
+    local ship_rotation = math.rad(self.GetRotation().y) * -1
+    for location, position in pairs(mount_positions) do
+        local transformed_position = {
+            ship_position.x + math.cos(ship_rotation) * position[1] - math.sin(ship_rotation) * position[2],
+            ship_position.y,
+            ship_position.z + math.sin(ship_rotation) * position[1] + math.cos(ship_rotation) * position[2]
+        }
+        mount_positions[location] = transformed_position
+    end
+
+    return mount_positions
+end
+
 function GetFixedArcs(args)
     local fixed_arcs = {}
     for _, arc in pairs(self.getTable("Data").arcs) do
@@ -6170,7 +6209,7 @@ end
 
 function SetTurretArc(args)
     local turret_position = args.turret or 'main'
-    assigned_arc_indicators[turret_position].call('setArc', {arc=args.arc})
+    assigned_arc_indicators[turret_position].call('setArc', {arc=args.arc, snap=args.snap})
 end
 
 -- Save self state

--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -1401,7 +1401,7 @@ AIModule.condition_functions['hasShot'] = function(ship, target, probe, argument
 
         local original_position_rotation = AIModule.GetPositionAndRotation(ship)
         AIModule.ApplyProbe(ship, probe)
-        targets = ArcCheck.GetTargetsInRelationToArc(ship, ship.getTable('Data').arcs) -- TODO: turrets won't work yet.
+        targets = ArcCheck.GetTargetsInRelationToArc(ship, ship.call('GetAllArcs'))
         targets = table.sieve(targets, AIModule.FilterInArc)
         targets = table.sieve(targets, AIModule.FilterInRange)
 
@@ -1423,7 +1423,7 @@ AIModule.condition_functions['inTargetsArc'] = function(ship, target, probe, arg
         AIModule.ApplyProbe(ship, probe)
 
         probe.in_targets_arc = false
-        targets = ArcCheck.GetTargetsInRelationToArc(target, target.getTable('Data').arcs, {ship}) -- TODO: turrets won't work yet
+        targets = ArcCheck.GetTargetsInRelationToArc(target, ship.call('GetAllArcs'), {ship})
         targets = table.sieve(targets, AIModule.FilterInArc)
         targets = table.sieve(targets, AIModule.FilterInRange)
         for _, target_info in pairs(targets) do
@@ -1538,7 +1538,7 @@ AIModule.condition_functions['inEnemyArc'] = function(ship, target, probe, argum
         -- within their arc. For each ship that can fire at us we increment the
         -- number of arcs.
         for _, enemy_ship in pairs(enemies_in_arc) do
-            local enemy_arc = ArcCheck.GetTargetsInRelationToArc(enemy_ship['ship'], enemy_ship['ship'].getTable('Data').arcs, {ship}) -- TODO: turrets won't work yet
+            local enemy_arc = ArcCheck.GetTargetsInRelationToArc(enemy_ship['ship'], enemy_ship['ship'].call('GetAllArcs'), {ship})
             enemy_arc = table.sieve(enemy_arc, AIModule.FilterInArc)
             enemy_arc = table.sieve(enemy_arc, AIModule.FilterInRange)
             for _ in pairs(enemy_arc) do

--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -6098,13 +6098,95 @@ function GetTokens(args)
     return tokens
 end
 
+assigned_arc_indicators = {}
+
+function AddArcIndicator(args)
+    assigned_arc_indicators[args.location] = args.indicator
+end
+
+function RemoveArcIndicator(args)
+    for location, indicator in pairs(assigned_arc_indicators) do
+        if indicator == args.indicator then
+            assigned_arc_indicators[location] = nil
+            break
+        end
+    end
+end
+
+function GetFixedArcs(args)
+    local fixed_arcs = {}
+    for _, arc in pairs(self.getTable("Data").arcs) do
+        if arc ~= 'doubleturret' and arc ~= 'singleturret' then
+            table.insert(fixed_arcs, arc)
+        end
+    end
+
+    return fixed_arcs
+end
+
+function GetTurretArcs(args)
+    local turret_arcs = {}
+    for _, arc_indicator in pairs(assigned_arc_indicators) do
+        local new_turret_arcs = arc_indicator.call('getArcs')
+
+        for _, new_arc in pairs(new_turret_arcs) do
+            local found = false
+            for _, existing_arc in pairs(turret_arcs) do
+                if new_arc == existing_arc then
+                    found = true
+                    break
+                end
+            end
+
+            if found == false then
+                table.insert(turret_arcs, new_arc)
+            end
+        end
+    end
+
+    return turret_arcs
+end
+
+function GetAllArcs(args)
+    local arcs = GetFixedArcs()
+    local turret_arcs = GetTurretArcs()
+
+    for _, turret_arc in pairs(turret_arcs) do
+        local found = false
+        for _, existing_arc in pairs(arcs) do
+            if turret_arc == existing_arc then
+                found = true
+                break
+            end
+        end
+
+        if found == false then
+            table.insert(arcs, turret_arc)
+        end
+    end
+
+    return arcs
+end
+
+function SetTurretArc(args)
+    local turret_position = args.turret or 'main'
+    assigned_arc_indicators[turret_position].call('setArc', {arc=args.arc})
+end
+
 -- Save self state
 function onSave()
     local state = {shipData=self.getTable("Data")}
+
+    state.tokenData = {arcs={}}
+    for location, indicator in pairs(assigned_arc_indicators) do
+        state.tokenData.arcs[location] = indicator.getGUID()
+    end
+
     return JSON.encode(state)
 end
 
 -- Restore self state
+arc_indicator_queue = {}
 function onLoad(savedData)
     --print("OnLoad: ".. self.getName() .. " " .. savedData)
     if savedData ~= "" and Data == nil then
@@ -6113,7 +6195,48 @@ function onLoad(savedData)
         if state.shipData.arcs ~= nil then
             initContextMenu()
         end
+
+        local any_arcs = false
+        for location, guid in pairs(state.tokenData.arcs) do
+            any_arcs = true
+            break
+        end
+
+        if any_arcs then
+            arc_indicator_queue = state.tokenData.arcs
+            startLuaCoroutine(self, 'waitForArcIndicatorsLoading')
+        end
     end
+end
+
+function waitForArcIndicatorsLoading()
+    repeat
+        coroutine.yield(0)
+    until setUpArcIndicators() == false
+
+    return 1
+end
+
+function setUpArcIndicators()
+    local added_arcs = {}
+    for location, guid in pairs(arc_indicator_queue) do
+        local arc_indicator = getObjectFromGUID(guid)
+        if arc_indicator ~= nil and arc_indicator.getVar('loaded') == true then
+            assigned_arc_indicators[location] = arc_indicator
+            arc_indicator.call('linkToShip', {ship=self})
+            table.insert(added_arcs, location)
+        end
+    end
+
+    for _, location in pairs(added_arcs) do
+        arc_indicator_queue[location] = nil
+    end
+
+    for _ in pairs(arc_indicator_queue) do
+        return true
+    end
+
+    return false
 end
 
 ]]

--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -6210,39 +6210,33 @@ function onLoad(savedData)
         end
         if any_arcs then
             arc_indicator_queue = state.tokenData.arcs
-            startLuaCoroutine(self, 'waitForArcIndicatorsLoading')
+            linkArcIndicators()
         end
     end
 end
 
-function waitForArcIndicatorsLoading()
-    repeat
-        coroutine.yield(0)
-    until setUpArcIndicators() == false
+function linkArcIndicators()
+    Wait.condition(
+        function()
+            for location, guid in pairs(arc_indicator_queue) do
+                local arc_indicator = getObjectFromGUID(guid)
+                assigned_arc_indicators[location] = arc_indicator
+                arc_indicator.call('linkToShip', {ship=self})
+            end
 
-    return 1
-end
+            arc_indicator_queue = {}
+        end,
+        function()
+            for location, guid in pairs(arc_indicator_queue) do
+                local arc_indicator = getObjectFromGUID(guid)
+                if arc_indicator == nil or arc_indicator.getVar('loaded') == false then
+                    return false
+                end
+            end
 
-function setUpArcIndicators()
-    local added_arcs = {}
-    for location, guid in pairs(arc_indicator_queue) do
-        local arc_indicator = getObjectFromGUID(guid)
-        if arc_indicator ~= nil and arc_indicator.getVar('loaded') == true then
-            assigned_arc_indicators[location] = arc_indicator
-            arc_indicator.call('linkToShip', {ship=self})
-            table.insert(added_arcs, location)
+            return true
         end
-    end
-
-    for _, location in pairs(added_arcs) do
-        arc_indicator_queue[location] = nil
-    end
-
-    for _ in pairs(arc_indicator_queue) do
-        return true
-    end
-
-    return false
+    )
 end
 
 ]]

--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -6177,9 +6177,12 @@ end
 function onSave()
     local state = {shipData=self.getTable("Data")}
 
-    state.tokenData = {arcs={}}
+    state.tokenData = {tokens={},arcs={}}
     for location, indicator in pairs(assigned_arc_indicators) do
         state.tokenData.arcs[location] = indicator.getGUID()
+    end
+    for guid, _ in pairs(assigned_tokens) do
+        table.insert(state.tokenData.tokens, guid)
     end
 
     return JSON.encode(state)
@@ -6196,12 +6199,15 @@ function onLoad(savedData)
             initContextMenu()
         end
 
+        for _, guid in ipairs(state.tokenData.tokens) do
+            assigned_tokens[guid] = getObjectFromGUID(guid)
+        end
+
         local any_arcs = false
         for location, guid in pairs(state.tokenData.arcs) do
             any_arcs = true
             break
         end
-
         if any_arcs then
             arc_indicator_queue = state.tokenData.arcs
             startLuaCoroutine(self, 'waitForArcIndicatorsLoading')

--- a/TTS_xwing/Arc Indicator.ttslua
+++ b/TTS_xwing/Arc Indicator.ttslua
@@ -13,22 +13,26 @@ __XW_TokenType = 'arcIndicator'
 -- Should it snap on the next collision
 snap = true
 
+-- The ship that we're mounted on
+ship = nil
+
+
 -- When colliding with a ship, set position to its center and rotation to nearest 90deg point
 -- Wait until resting after every snap
 function onCollisionEnter(collision_info)
     local body = collision_info.collision_object
     if (not loaded) or (not snap) or (not body) or body.tag ~= 'Figurine' then return end
-    local relRot = self.getRotation()[2] - body.getRotation()[2]
-    local tRot = math.round(relRot/90)*90 + body.getRotation()[2]
-    local tPos = body.getPosition()
-    self.setPositionSmooth({tPos[1], tPos[2]+0.3, tPos[3]}, false, true)
-    self.setRotationSmooth({0, tRot, 0}, false, true)
-    snap = false
-    startLuaCoroutine(self, 'waitForResting')
-end
 
-function onLoad(save_state)
-    loaded = true
+    -- ship should always be nil, but just in case:
+    if ship ~= body then
+        detachFromShip()
+    end
+
+    attachToShip(body)
+
+    snap = false
+
+    startLuaCoroutine(self, 'waitForResting')
 end
 
 function waitForResting()
@@ -37,6 +41,55 @@ function waitForResting()
     end
     snap = true
     return 1
+end
+
+function onLoad(save_state)
+    loaded = true
+end
+
+function onPickUp(player_color)
+    detachFromShip()
+end
+
+function attachToShip(new_ship)
+    ship = new_ship
+
+    -- TODO: We're currently defaulting to the "main" mount, at the centre of
+    -- the model. We need to check if we're attaching to a huge ship, and if so,
+    -- seeing if we're closer to the front or rear mount and attach to that.
+    -- The indicator also needs to snap to the huge ship's hardpoints instead
+    -- of the centre of the model.
+    local tPos = ship.getPosition()
+    self.setPositionSmooth({tPos[1], tPos[2]+0.3, tPos[3]}, false, true)
+
+    self.setRotationSmooth({0, getRelativeRotation(true), 0}, false, true)
+
+    -- TODO: Pass in "front" or "back" for huge ships, instead of "main".
+    ship.call('AddArcIndicator', {indicator=self, location='main'})
+end
+
+function detachFromShip()
+    if ship ~= nil then
+        ship.call('RemoveArcIndicator', {indicator=self})
+        ship = nil
+    end
+end
+
+function getRelativeRotation(roundToCardinal)
+    local relative_rotation = self.getRotation()[2] - ship.getRotation()[2]
+
+    -- Normalise to within 0 - 360
+    while relative_rotation < 0 do
+        relative_rotation = relative_rotation + 360
+    end
+    while relative_rotation > 360 do
+        relative_rotation = relative_rotation - 360
+    end
+
+    if roundToCardinal == true then
+        relative_rotation = math.round(relative_rotation/90)*90 + ship.getRotation()[2]
+    end
+    return relative_rotation
 end
 
 -- Round to decPlaces decimal places
@@ -55,4 +108,66 @@ function math.round(arg, decPlaces)
         local mult = 10^(decPlaces or 0)
         return math.floor(arg * mult + 0.5) / mult
     end
+end
+
+-- Called by the ship upon loading a save game.
+function linkToShip(args)
+    if ship ~= args.ship then
+        ship = args.ship
+    end
+end
+
+-- Externally accessible call that returns which arc this indicator is pointing
+-- in.
+function getArcs(args)
+    if ship == nil then
+        return {}
+    end
+
+    local relative_rotation = getRelativeRotation(false)
+
+    -- TODO: Should we replace this with different scripts instead?
+    if string.find(self.getName(), 'Dual') ~= nil then
+        if relative_rotation < 45 then
+            return {'front', 'back'}
+        elseif relative_rotation < 135 then
+            return {'left', 'right'}
+        elseif relative_rotation < 225 then
+            return {'front', 'back'}
+        elseif relative_rotation < 315 then
+            return {'left', 'right'}
+        else
+            return {'front', 'back'}
+        end
+    else
+        if relative_rotation < 45 then
+            return {'front'}
+        elseif relative_rotation < 135 then
+            return {'right'}
+        elseif relative_rotation < 225 then
+            return {'back'}
+        elseif relative_rotation < 315 then
+            return {'left'}
+        else
+            return {'front'}
+        end
+    end
+end
+
+function setArc(args)
+    if ship == nil then
+        return
+    end
+
+    relRot = 0
+    if args.arc == 'right' or args.arc == 'leftright' then
+        relRot = 90
+    elseif args.arc == 'back' then
+        relRot = 180
+    elseif args.arc == 'left' then
+        relRot = 270
+    end
+
+    local tRot = relRot + ship.getRotation()[2]
+    self.setRotationSmooth({0, tRot, 0}, false, true)
 end

--- a/TTS_xwing/Arc Indicator.ttslua
+++ b/TTS_xwing/Arc Indicator.ttslua
@@ -24,11 +24,12 @@ function onCollisionEnter(collision_info)
     if (not loaded) or (not snap) or (not body) or body.tag ~= 'Figurine' then return end
 
     -- ship should always be nil, but just in case:
-    if ship ~= body then
+    if ship == body then
+        snapToArc()
+    else
         detachFromShip()
+        attachToShip(body)
     end
-
-    attachToShip(body)
 
     snap = false
 
@@ -52,20 +53,36 @@ function onPickUp(player_color)
 end
 
 function attachToShip(new_ship)
+    -- Get the mount positions and, if there are more than one, see which
+    -- one we're closest to.
+    local mount_positions = new_ship.call('GetAvailableMountPositions')
+    local closest_mount_position = nil
+    local closest_squared_distance = nil
+
+    for mount, position in pairs(mount_positions) do
+        local x_distance = self.getPosition()[1] - position[1]
+        local z_distance = self.getPosition()[3] - position[3]
+        local squared_distance = x_distance * x_distance + z_distance * z_distance
+        if closest_squared_distance == nil or closest_squared_distance > squared_distance then
+            closest_mount_position = mount
+            closest_squared_distance = squared_distance
+        end
+    end
+
+    -- If we couldn't find an available mount position, then we can't attach
+    -- to this ship.
+    if closest_mount_position == nil then
+        return false
+    end
     ship = new_ship
 
-    -- TODO: We're currently defaulting to the "main" mount, at the centre of
-    -- the model. We need to check if we're attaching to a huge ship, and if so,
-    -- seeing if we're closer to the front or rear mount and attach to that.
-    -- The indicator also needs to snap to the huge ship's hardpoints instead
-    -- of the centre of the model.
-    local tPos = ship.getPosition()
-    self.setPositionSmooth({tPos[1], tPos[2]+0.3, tPos[3]}, false, true)
+    -- Set our position to the chosen mount.
+    self.setPositionSmooth({mount_positions[closest_mount_position][1], mount_positions[closest_mount_position][2] + 0.3, mount_positions[closest_mount_position][3]}, false, true)
 
-    self.setRotationSmooth({0, getRelativeRotation(true), 0}, false, true)
+    snapToArc()
 
-    -- TODO: Pass in "front" or "back" for huge ships, instead of "main".
-    ship.call('AddArcIndicator', {indicator=self, location='main'})
+    -- Set up the ship-side attachment.
+    ship.call('AddArcIndicator', {indicator=self, location=closest_mount_position})
 end
 
 function detachFromShip()
@@ -73,6 +90,10 @@ function detachFromShip()
         ship.call('RemoveArcIndicator', {indicator=self})
         ship = nil
     end
+end
+
+function snapToArc()
+    self.setRotationSmooth({0, getRelativeRotation(true), 0}, false, true)
 end
 
 function getRelativeRotation(roundToCardinal)
@@ -169,5 +190,9 @@ function setArc(args)
     end
 
     local tRot = relRot + ship.getRotation()[2]
-    self.setRotationSmooth({0, tRot, 0}, false, true)
+    if args.snap == true then
+        self.setRotation({0, tRot, 0})
+    else
+        self.setRotationSmooth({0, tRot, 0}, false, true)
+    end
 end


### PR DESCRIPTION
This PR covers a few things:
- Fixes an issue that made the AI treat all action combinations as the same difficulty, which led to the Interceptor not preferring white actions over red linked actions.
- Adds intelligence into the arc indicators, so now they are linked to ships and can have their arc queried and set programatically.
- Huge ships have two mount points for arc indicators.
- The AI takes enemy arcs indicators into account.

One thing to note is that I haven't updated the ship generation code, so huge ships still will only get one arc indicator regardless of how many they actually need.