### PR TITLE
AI: Ionised focus actions, obstacle types

### DIFF
--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -801,7 +801,14 @@ AIModule.ManeuverPostShipRest = function(ship)
         DialModule.PerformAction(ship, 'Stress', ship.getVar("owningPlayer"))
     elseif AIModule.current_move.take_action == true and AIModule.current_move.stress_count == 0 and AIModule.current_move.collision == false and AIModule.current_move.obstacle == false then
         if AIModule.current_move.is_ionised then
-            -- TODO: Only perform a focus action (if possible)
+            -- Ionised ships can only perform a focus action, if possible.
+            for _, action in pairs(ship.getTable('Data')['actSet']) do
+                if action == 'F' then
+                    table.insert(AIModule.current_move.action_stack, 'focus')
+                    action_selected = true
+                    break
+                end
+            end
         else
             -- Check for Full Throttle and apply it now if appropriate.
             AIModule.ApplySpecialAbility(ship, 'fullThrottle')

--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -733,6 +733,21 @@ AIModule.PerformManeuver = function(ship, take_action)
                             AIModule.current_move.collision = swerve_probe_data.collObj ~= nil
                         else
                             print(' Tried ' .. closest_swerve_move_code .. ', still hits an obstacle.')
+
+                            local obstacle_name = swerve_probe_data.collObs.getName()
+                            if obstacle_name:find('Asteroid') then
+                                -- Asteroid: roll an attack die and suffer a hit or crit
+                                AIModule.current_move.obstacle = 'asteroid'
+                                printToAll(ship.GetName() .. ' has collided with an asteroid. Please roll a red die and inflict a hit or a critical hit if either is rolled.', color(1.0, 1.0, 0.2, 0.9))
+                            elseif obstacle_name:find('Debris') or obstacle_name:find('Chute debris') or obstacle_name:find('Spare') then
+                                -- Debris cloud: gain stress (happens in ManeuverPostShipRest), roll and attack die and suffer a crit
+                                AIModule.current_move.obstacle = 'debris_field'
+                                printToAll(ship.GetName() .. ' has collided with a debris field. Please roll a red die and inflict a critical hit if one is rolled.', color(1.0, 1.0, 0.2, 0.9))
+                            elseif obstacle_name:find('Cloud') then
+                                AIModule.current_move.obstacle = 'gas_cloud'
+                                -- Gas cloud: roll an attack die, gain a strain on an eye or a hit
+                                printToAll(ship.GetName() .. ' has collided with a gas cloud. Please roll a red die and gain a strain if an eye or a hit is rolled.', color(1.0, 1.0, 0.2, 0.9))
+                            end
                         end
                     end
                 end
@@ -796,6 +811,10 @@ end
 
 AIModule.ManeuverPostShipRest = function(ship)
     local action_selected = false;
+
+    if AIModule.current_move.obstacle == 'debris_field' then
+        DialModule.PerformAction(ship, 'Stress', ship.getVar("owningPlayer"))
+    end
 
     if AIModule.current_move.difficulty == 'r' then
         DialModule.PerformAction(ship, 'Stress', ship.getVar("owningPlayer"))

--- a/TTS_xwing/src/ContextGui.ttslua
+++ b/TTS_xwing/src/ContextGui.ttslua
@@ -30,7 +30,7 @@ ContextGui.onObjectHover = function(player_color, hovered_object)
             hovered_object.call("onHoverLeave", player_color)
         end
     end
-    if (hovered_object ~= nil)
+    if (hovered_object ~= nil) then
         if (hovered_object.getVar("onContextOpen") ~= nil) then
             ContextGui.playerTable[player_color].timerid = Wait.time(function() ContextGui.onTimout(player_color, hovered_object) end, 1)
         end


### PR DESCRIPTION
A small update to the AI:

- Ionised ships now check if they have the focus action available, and if they do, then they will take it.
- When colliding with obstacles, AI ships will check what type it is and handle it appropriately. Most of the time this just posts a message in the chat requesting that the player handle the die roll.