### PR TITLE
Fix missing collision note

### DIFF
--- a/Global.-1.ttslua
+++ b/Global.-1.ttslua
@@ -2881,6 +2881,7 @@ MoveData.DecodeInfo = function (move_code, ship)
         if move_code:sub(2,2) == 'l' or move_code:sub(2,2) == 'e' then
             info.dir = 'left'
         end
+        info.collNote = 'tried barrel rolling ' .. info.dir
         info.speed = tonumber(move_code:sub(3,3))
         info.traits.full = true
         info.traits.part = false


### PR DESCRIPTION
Fixes a bug for move proxy in the case that there are no available barrel rolls due to ship collision