### PR TITLE
Add dial proxy mode

### DIFF
--- a/TTS_xwing/src/Dial/Button.ttslua
+++ b/TTS_xwing/src/Dial/Button.ttslua
@@ -1,0 +1,87 @@
+local obj = self
+
+local B = {}
+
+local offsetXY = {
+    Setup = "0 0",
+    proxyPanel = "0 -215",
+}
+
+local function changeButtonState(button, activate)
+    if activate then
+        obj.UI.setAttribute(button, "active", "true")
+        -- deactivating a button resets text color to black, we have to set it again
+        obj.UI.setAttribute(button, "textColor", "#FFFFFF")
+    else
+       obj.UI.setAttribute(button, "active", "false")
+    end
+end
+
+function B.setAttributeFacing(attribute, face_state)
+    local up_rotation   = "0 180 0"
+    local down_rotation = "0 0 0"
+    local up_z          = "1"
+    local down_z        = "-25"
+    local base_xy = offsetXY[attribute]
+
+    local attributes = {}
+    if face_state == "Down" then
+        attributes = {
+            position = base_xy .. " " .. down_z,
+            rotation = down_rotation,
+        }
+    elseif face_state == "Up" then
+        attributes = {
+            position = base_xy .. " " .. up_z,
+            rotation = up_rotation,
+        }
+    end
+
+    obj.UI.setAttributes(attribute, attributes)
+end
+
+function B.setProxyState(activate, cancellable, active_proxies)
+    if activate then
+        obj.UI.show("proxyPanel")
+    else
+        obj.UI.hide("proxyPanel")
+    end
+
+    changeButtonState("proxyCancelBtn", cancellable)
+
+    if not cancellable then
+        changeButtonState("UndoBtn", not activate)
+    end
+
+    if not active_proxies then
+        obj.UI.setAttribute("proxyFrontBtn", "active", "false")
+        obj.UI.setAttribute("proxyCenterBtn", "active", "false")
+        obj.UI.setAttribute("proxyBackBtn", "active", "false")
+
+        return
+    end
+    for position, guid in pairs(active_proxies) do
+        local attribute_name = string.upper(position:sub(1,1)) .. position:sub(2,-1)
+        obj.UI.setAttribute("proxy"..attribute_name.."Btn", "onMouseEnter", guid.."/onHoverEnter")
+        obj.UI.setAttribute("proxy"..attribute_name.."Btn", "onMouseExit", guid.."/onHoverLeave")
+        obj.UI.setAttribute("proxy"..attribute_name.."Btn", "onClick", guid.."/select")
+        obj.UI.setAttribute("proxy"..attribute_name.."Btn", "active", "true")
+    end
+end
+
+function B.setBarrelRollState(proxyMode, activate)
+    if activate then
+        obj.UI.setAttribute("BarrelRightFD", "active", "true")
+        obj.UI.setAttribute("BarrelLeftFD", "active", "true")
+        obj.UI.setAttribute("BarrelRBtn", "active", "true")
+        obj.UI.setAttribute("BarrelLBtn", "active", "true")
+    end
+
+    local extra_buttons = tostring(not proxyMode)
+    obj.UI.setAttribute("BarrelRFBtn", "active", extra_buttons)
+    obj.UI.setAttribute("BarrelRBBtn", "active", extra_buttons)
+    obj.UI.setAttribute("BarrelLFBtn", "active", extra_buttons)
+    obj.UI.setAttribute("BarrelLBBtn", "active", extra_buttons)
+end
+
+return B

--- a/TTS_xwing/src/Dial/Menu.ttslua
+++ b/TTS_xwing/src/Dial/Menu.ttslua
@@ -27,7 +27,7 @@ function M.update()
             text = "Enable " .. v.text
         end
 
-        obj.addContextMenuItem(text, || v.func(not value) )
+        obj.addContextMenuItem(text, || v.func(not value))
     end
 end
 

--- a/TTS_xwing/src/Dial/Proxy.ttslua
+++ b/TTS_xwing/src/Dial/Proxy.ttslua
@@ -1,0 +1,86 @@
+local obj = self
+
+local P = {}
+
+local active_proxies = {}
+
+local function createOffsets(move_code, offsets)
+    local outputs = {}
+
+    if move_code:sub(1,1) == "r" then
+        move_code = move_code:sub(1,2)
+    elseif move_code:sub(-1,-1) == "t" then
+        move_code = move_code:sub(1,3)
+    end
+
+    for c, v in pairs(offsets) do
+        outputs[c] = move_code..v
+    end
+
+    return outputs
+end
+
+local function isActive()
+    if not active_proxies then return false end
+
+    for k, v in pairs(active_proxies)do return true end
+    return false
+end
+
+local function isDone(proxy)
+    return proxy.state == "term"
+end
+
+local function isReady(proxy)
+    return proxy.state == "active"
+end
+
+local function setActiveProxies(proxies)
+    for position, proxy in pairs(proxies) do
+       active_proxies[position] = proxy.getGUID()
+    end
+end
+
+local function unsetActiveProxies()
+    active_proxies = {}
+end
+
+function P.cancel(ship_guid)
+    Global.call("DeleteShipProxies", {ship_guid = ship_guid})
+end
+
+function P.isProxyable(move_code)
+    return move_code:sub(1,1) == "r"
+end
+
+function P.spawn(args)
+    if isActive() then 
+        printToAll("Please finish this ship's active proxy maneuver before setting another one")
+        return
+    end
+
+    local ship_guid   = args.ship_guid
+    local move_code   = args.move_code
+    local offsets     = args.offsets
+    local cancellable = args.cancellable
+    local button_func = args.button_func
+
+    local move_codes = createOffsets(move_code, offsets)
+    local proxy_args = {
+        ship_guid  = ship_guid,
+        move_codes = move_codes,
+    }
+
+    local proxy_objects, success = Global.call("SpawnProxyOptions", proxy_args)
+
+    if not success then return end
+
+    Wait.condition(|| setActiveProxies(proxy_objects.proxy_table),    || isReady(proxy_objects))
+    Wait.condition(|| button_func(true, cancellable, active_proxies), || isReady(proxy_objects))
+
+    Wait.condition(   unsetActiveProxies,         || isDone(proxy_objects))
+    Wait.condition(|| button_func(false),         || isDone(proxy_objects))
+    Wait.condition(|| obj.setVar("befAft", "_A"), || isDone(proxy_objects))
+end
+
+return P

--- a/TTS_xwing/src/ShipProxy.ttslua
+++ b/TTS_xwing/src/ShipProxy.ttslua
@@ -4,6 +4,52 @@
 --
 -- Module for handeling ship proxies, used in barrel rolls and more
 -- ~~~~~~
+local ShipProxyInstance = {
+    state        = nil,
+    proxy_table  = {},
+    proxy_status = {},
+}
+
+function ShipProxyInstance:new ()
+    o = {}
+    setmetatable(o, self)
+    self.__index = self
+
+    self.state = "init"
+    return o
+end
+
+function ShipProxyInstance:setActive ()
+    self.state = "active"
+end
+
+function ShipProxyInstance:ready ()
+    if not self.proxy_table then return false end
+
+    for position, proxy in pairs(self.proxy_table) do
+        if proxy.getGUID() ~= "" then return true end
+    end
+
+    return false
+end
+
+function ShipProxyInstance:add (position, proxy)
+    if not proxy then
+        return
+    end
+
+    self.proxy_table[position] = proxy
+end
+
+function ShipProxyInstance:destroy ()
+    self.state = "term"
+
+    for position, proxy in pairs(self.proxy_table) do
+        proxy.destruct()
+        self.proxy_table[position] = nil
+    end
+end
+
 ShipProxyModule = {}
 ShipProxyModule.proxyTable = {}
 ShipProxyModule.hiddenShips = {}
@@ -117,7 +163,10 @@ end
 
 function MarkShip(args)
     local finpos = { pos = args.ship.getPosition(), rot = args.ship.getRotation() }
-    ShipProxyModule.spawnProxy(args.ship, true, finpos, false, "markShip")
+    local proxy = ShipProxyModule.spawnProxy(args.ship, true, finpos, false, "markShip")
+
+    ShipProxyModule.proxyTable[args.ship.getGUID()] = ShipProxyModule.proxyTable[args.ship.getGUID()] or {}
+    table.insert(ShipProxyModule.proxyTable[args.ship.getGUID()], proxy)
 end
 
 function UnMarkShip(args)
@@ -128,12 +177,8 @@ function UnMarkShip(args)
         ship.interactable = true
         ShipProxyModule.hiddenShips[args.shipGUID] = nil
     end
-    for k, proxy in pairs( ShipProxyModule.proxyTable[args.shipGUID]) do
-        if proxy ~= nil then
-            proxy.destruct()
-        end
-    end
-     ShipProxyModule.proxyTable[args.shipGUID] = nil;
+    DeleteShipProxies({ship_guid = args.shipGUID})
+    ShipProxyModule.proxyTable[args.shipGUID] = nil;
 end
 
 function StartBarrelRoll(args)
@@ -149,9 +194,14 @@ function StartBarrelRoll(args)
 
     local collide = true
     for i, v in ipairs(offsets) do
-        local result = ShipProxyModule.CreateMoveProxy(v, ship)
+        local proxy, result = ShipProxyModule.CreateMoveProxy(v, ship)
         if result ~= 'overlap' then
             collide = false
+        end
+
+        if proxy then
+            ShipProxyModule.proxyTable[args.ship.getGUID()] = ShipProxyModule.proxyTable[args.ship.getGUID()] or {}
+            table.insert(ShipProxyModule.proxyTable[args.ship.getGUID()], proxy)
         end
     end
 
@@ -162,12 +212,59 @@ function StartBarrelRoll(args)
     end
 end
 
+local function executeFailure(move_code, ship, finType)
+    if finType == 'overlap' then
+        local info = MoveData.DecodeInfo(move_code:sub(1,-2), ship)
+        local annInfo = {type='overlap', note=info.collNote, code=info.code}
+        AnnModule.Announce(annInfo, 'all', ship)
+
+        return
+    end
+
+    MoveModule.PerformMove(move_code, ship)
+end
+
+function SpawnProxyOptions(args)
+    local ship       = getObjectFromGUID(args.ship_guid)
+    local move_codes = args.move_codes or {}
+    local base_position  = args.base_position or 'center'
+
+    local ok = nil
+    local finType = nil
+    local ship_proxies = ShipProxyInstance:new()
+    for position, move_code in pairs(move_codes) do
+        local proxy, finPos = ShipProxyModule.CreateMoveProxy(move_code, ship)
+        if finPos.finType == 'move' and finPos.finPart == 'max' then
+            ok = true
+        else
+            finType = finPos.finType
+        end
+
+        ship_proxies:add(position, proxy)
+    end
+
+    if not ok then
+        executeFailure(move_codes[base_position], ship, finType)
+
+        return nil, false
+    end
+
+    Wait.condition(|| ship_proxies:setActive(), || ship_proxies:ready())
+
+    ShipProxyModule.proxyTable[ship.getGUID()] = ShipProxyModule.proxyTable[ship.getGUID()] or {}
+    table.insert(ShipProxyModule.proxyTable[ship.getGUID()], ship_proxies)
+    return ship_proxies, true
+end
+
 ShipProxyModule.CreateMoveProxy = function(move_code, ship)
     local info = MoveData.DecodeInfo(move_code, ship)
     local finalPos = MoveModule.GetFinalPosData(move_code, ship)
 
     if finalPos.finType == 'overlap' then
-        return finalPos.finType
+        return nil, finalPos
+    end
+    if finalPos.finPart ~= 'max' then
+        return nil, finalPos
     end
 
     local templateData = {
@@ -187,8 +284,8 @@ ShipProxyModule.CreateMoveProxy = function(move_code, ship)
         didCollide = true
     end
 
-    ShipProxyModule.spawnProxy(ship, false, finalPos.finPos, didCollide, "finalPos", move_code)
-    return finalPos.finType
+    local proxy = ShipProxyModule.spawnProxy(ship, false, finalPos.finPos, didCollide, "finalPos", move_code)
+    return proxy, finalPos
 end
 
 function SelectFinalPos(args)
@@ -196,11 +293,7 @@ function SelectFinalPos(args)
     local move_code = args.move_code
     MoveModule.PerformMove(move_code, ship)
 
-    for k, proxy in pairs( ShipProxyModule.proxyTable[args.shipGUID]) do
-        if proxy ~= nil then
-            proxy.destruct()
-        end
-    end
+    DeleteShipProxies({ship_guid = args.shipGUID})
 end
 
 ShipProxyModule.StartFinalPositionSelection = function(ship, positionOffset)
@@ -208,6 +301,19 @@ ShipProxyModule.StartFinalPositionSelection = function(ship, positionOffset)
     local offset = ShipProxyModule.finalPosOffset[size]
     for k, off in pairs({offset, vector(0,0,0), vector(0,0,0)-offset}) do
         ShipProxyModule.spawnProxy(ship, false, positionOffset + off, color(0,0.1,1,0.2), "finalPos")
+    end
+end
+
+function DeleteShipProxies(args)
+    local ship_guid = args.ship_guid
+
+    for i = 1,table.size(ShipProxyModule.proxyTable[ship_guid]) do
+        local proxy = table.remove(ShipProxyModule.proxyTable[ship_guid])
+        if proxy.destroy then
+            proxy:destroy()
+        else
+            proxy.destruct()
+        end
     end
 end
 
@@ -278,6 +384,5 @@ ShipProxyModule.spawnProxy = function(ship, hide, finpos, didCollide, script, mo
         end
     end
 
-    ShipProxyModule.proxyTable[ship.getGUID()] = ShipProxyModule.proxyTable[ship.getGUID()] or {}
-    table.insert(ShipProxyModule.proxyTable[ship.getGUID()], proxy)
+    return proxy
 end

--- a/Unassigned Dial.ttslua
+++ b/Unassigned Dial.ttslua
@@ -1,4 +1,6 @@
-menu = require("TTS_xwing/src/Dial/Menu")
+menu   = require("TTS_xwing/src/Dial/Menu")
+button = require("TTS_xwing/src/Dial/Button")
+proxy  = require("TTS_xwing/src/Dial/Proxy")
 
 -- ~~~~~~
 -- Script by dzikakulka
@@ -23,6 +25,7 @@ opencolor = "#555555"
 closedcolor = "#222222"
 
 clickMode = nil
+proxyMode = nil
 finished_setup = true
 
 -- Save self state
@@ -30,7 +33,9 @@ function onSave()
     if assignedShip ~= nil then
         local state = {assignedShipGUID=assignedShip.getGUID(),
                         owningPlayer=playerColor,
-                        clickMode = clickMode}
+                        clickMode = clickMode,
+                        proxyMode = proxyMode,
+                    }
         return JSON.encode(state)
     end
 end
@@ -54,6 +59,7 @@ function onLoad(savedData)
     if savedData ~= nil then
         state = JSON.decode(savedData)
         clickMode = state.clickMode
+        proxyMode = state.proxyMode
         --savedShip = getObjectFromGUID(state.assignedShipGUID)
         --playerColor = state.owningPlayer
         --if savedShip ~= nil then
@@ -62,6 +68,7 @@ function onLoad(savedData)
     end
 
     menu.addToggleItem("clickMode", "click mode", toggleClickMode)
+    menu.addToggleItem("proxyMode", "proxy mode", toggleProxyMode)
     menu.update()
 end
 
@@ -101,8 +108,6 @@ function onUpdate()
                 if finished_setup then
                     self.UI.show("CenterFD")
                 else
-                    self.UI.setAttribute("Setup", "rotation", "180 180 180")
-                    self.UI.setAttribute("Setup", "position", "0 0 -25")
                     self.UI.show('Setup')
                 end
             end
@@ -114,12 +119,13 @@ function onUpdate()
                 if finished_setup then
                     self.UI.show("CenterFU")
                 else
-                    self.UI.setAttribute("Setup", "rotation", "0 180 0")
-                    self.UI.setAttribute("Setup", "position", "0 0 0")
                     self.UI.show('Setup')
                 end
             end
         end
+
+        button.setAttributeFacing("Setup", faceStat or "Down")
+        button.setAttributeFacing("proxyPanel", faceStat or "Down")
     end
 end
 
@@ -243,7 +249,7 @@ function Undo(p)
     end
     assignedShip.setDescription("q")
     self.UI.setAttribute("UndoBtn", "active", "false")
-    if setMan:sub(-1,-1) ~='t' then
+    if setMan:sub(-1,-1) ~='t' or proxyMode then
         self.UI.setAttribute("MoveBtn", "active", "true")
         self.UI.setAttribute("MoveBtn", "textColor", "#FFFFFF")
     else
@@ -323,7 +329,19 @@ function performMove(P)
         if exOptions[curMan] ~= nil and exOptSelected == false then
             setupAlternateExecutionPanel(P, exOptions[curMan])
         elseif setMan:sub(-1,-1) == 't' then
-            self.UI.show("TalonPanel")
+            if proxyMode then
+                proxy_settings = {
+                    ship_guid   = assignedShip.getGUID(),
+                    move_code   = setMan,
+                    offsets     = {front = 'ft', center = 't', back = 'bt'},
+                    button_func = button.setProxyState,
+                }
+                proxy.spawn(proxy_settings)
+                exOptSelected = false
+                setDial(P)
+            else
+                self.UI.show("TalonPanel")
+            end
         else
             self.UI.setAttribute("UndoBtn", "active", "true")
             self.UI.setAttribute("UndoBtn", "textColor", "#FFFFFF")
@@ -408,6 +426,8 @@ function assignShip(ship)
     self.UI.setAttribute("CenterFU", "active", "true")
     self.UI.setAttribute("arcPanel", "active", "true")
     self.UI.setAttribute("tokenPanel", "active", "true")
+    self.UI.setAttribute("proxyPanel", "active", "true")
+    self.UI.hide("proxyPanel")
     self.UI.setAttribute("relocPanel", "active", "true")
     self.UI.setAttribute("setManPeekPanel", "active", "true")
     assignedShip = ship
@@ -440,14 +460,7 @@ function assignShip(ship)
             self.UI.setAttribute("CloakBtn", 'active', 'true')
         elseif v == 'BR' then
             repos = true
-            self.UI.setAttribute("BarrelRightFD", "active", "true")
-            self.UI.setAttribute("BarrelLeftFD", "active", "true")
-            self.UI.setAttribute("BarrelRBtn", "active", "true")
-            self.UI.setAttribute("BarrelRFBtn", "active", "true")
-            self.UI.setAttribute("BarrelRBBtn", "active", "true")
-            self.UI.setAttribute("BarrelLBtn", "active", "true")
-            self.UI.setAttribute("BarrelLFBtn", "active", "true")
-            self.UI.setAttribute("BarrelLBBtn", "active", "true")
+            button.setBarrelRollState(proxyMode, true)
         elseif v == 'B' then
             repos = true
             self.UI.setAttribute("BoostFD", "active", "true")
@@ -673,7 +686,25 @@ function Repos(P, option, id)
     if (option ~= '-1') or (spectReturn(P) == true) then
         return
     end
-    assignedShip.setDescription(reposCommands[id] or "")
+
+    local move_code = reposCommands[id] or ""
+    if proxyMode and proxy.isProxyable(move_code) then
+        proxy_settings = {
+            ship_guid   = assignedShip.getGUID(),
+            move_code   = move_code,
+            offsets     = {front = '1', center = '2', back = '3'},
+            cancellable = true,
+            button_func = button.setProxyState,
+        }
+
+        proxy.spawn(proxy_settings)
+    else
+        assignedShip.setDescription(move_code)
+    end
+end
+
+function CancelProxy(player, option, id)
+    proxy.cancel(assignedShip.getGUID())
 end
 
 arcCommands = {
@@ -801,6 +832,14 @@ function toggleClickMode(enable)
     self.UI.setAttribute("arcPanel", "raycastTarget", not clickMode)
     self.UI.setAttribute("tokenPanel", "raycastTarget", not clickMode)
     self.UI.setAttribute("relocPanel", "raycastTarget", not clickMode)
+
+    menu.update()
+end
+
+function toggleProxyMode(enable)
+    proxyMode = enable
+
+    button.setBarrelRollState(proxyMode)
 
     menu.update()
 end
@@ -1006,3 +1045,4 @@ function deleteTemplate()
   Table={[1]=assignedShip,[2]='deleteMoveTemplate',[3]=playerColor}
   Global.call("proxyPerformAction",Table)
 end
+

--- a/Unassigned Dial.xml
+++ b/Unassigned Dial.xml
@@ -281,6 +281,58 @@
     </Panel>
 </Panel>
 
+<Panel id="proxyPanel"
+	active="false"
+	width="700"
+	height="150"
+	position="0 -265 -25"
+	color="#aaaaaa00"
+	showAnimation="FadeIn"
+	hideAnimation="FadeOut"
+	raycastTarget="true">
+	<VerticalLayout childAlignment="MiddleBottom"
+		childForceExpandHeight="false"
+		spacing="5">
+		<HorizontalLayout childAlignment="MiddleCenter"
+			childForceExpandWidth="false"
+			spacing="5">
+			<Button id="proxyFrontBtn"
+				class="RelocButtons"
+				active="false">
+				<Image id="TalonForIcon"
+					class="RIcon"
+					image="TalonFront"
+					preserveAspect="true"></Image>
+			</Button>
+			<Button id="proxyCenterBtn"
+				class="RelocButtons"
+				active="false">
+				<Image id="TalonMidIcon"
+					class="RIcon"
+					image="TalonMid"
+					preserveAspect="true"></Image>
+			</Button>
+			<Button id="proxyBackBtn"
+				class="RelocButtons"
+				active="false">
+				<Image id="TalonReaIcon"
+					class="RIcon"
+					image="TalonRear"
+					preserveAspect="true"></Image>
+			</Button>
+		</HorizontalLayout>
+		<Panel>
+			<Button id="proxyCancelBtn"
+				class="DarkButton"
+				onClick="CancelProxy"
+				height="60"
+				width="180"
+				rotation="0 0 180"
+				fontStyle="Bold">Cancel</Button>
+		</Panel>
+	</VerticalLayout>
+</Panel>
+
 <Panel id="relocPanel"
     active="false"
     width="700"


### PR DESCRIPTION
- Implements barrel roll proxy mode with dial initialization
- Implements tallon roll control and dial control of final position

Notes:
- Return quickly when active proxies set. Multiple proxies don't play
  nice with dial buttons.
- Create uniform function for flipping. Should be refactored to include
  all other button flips (e.g. FD -> FU / FU -> FD)
- Tallon rolls, unlike barrel rolls can't "fail" and be cancelled. They
  don't have a cancel button.