### PR TITLE
Scum & FO Move Improvements

### DIFF
--- a/TTS_xwing/src/BehaviourDB.ttslua
+++ b/TTS_xwing/src/BehaviourDB.ttslua
@@ -2941,37 +2941,38 @@ BehaviourDB.rule_sets[1].ships['modifiedtielnfighter'].action_selection = {
 BehaviourDB.rule_sets[1].ships['customizedyt1300lightfreighter'] = {}
 BehaviourDB.rule_sets[1].ships['customizedyt1300lightfreighter'].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
 BehaviourDB.rule_sets[1].ships['customizedyt1300lightfreighter'].move_table = {
-    bullseye = {
-    	near = {[1] = 'tl2', [3] = 'tr2', [5] = 'tl3', [6] = 'tr3'},
-    	far = {[1] = 's1', [2] = 's2', [5] = 's3'},
-    	distant = {[1] = 's3', [2] = 's4'},
-    	stress = {[1] = 's1', [4] = 's2'},
-    },
-    front_right = {
-    	near = {[1] = 'bl1', [3] = 'tl2', [6] = 'bl2'},
-    	far = {[1] = 'br1', [4] = 'br2', [6] = 's3'},
-    	distant = {[1] = 'br3', [5] = 's4'},
-    	stress = {[1] = 's1', [2] = 'bl1', [3] = 'br1'},
-    },
-    right_front = {
-    	near = {[1] = 'bl1', [2] = 'bl2', [4] = 's2'},
-    	far = {[1] = 'br1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
-    	distant = {[1] = 'tr2', [4] = 'tr3'},
-    	stress = {[1] = 'bl1', [3] = 'br1', [6] = 'tr2'},
-    },
-    right_back = {
-    	near = {[1] = 'bl3s', [3] = 'br1', [4] = 'tr2'},
-    	far = {[1] = 'k4', [2] = 'bl3s', [5] = 'tr2'},
-    	distant = {[1] = 'br3s', [4] = 'tr2'},
-    	stress = {[1] = 'bl1', [3] = 'br1'},
-    },
-    back_right = {
-    	near = {[1] = 'k4', [2] = 'bl3s', [4] = 'tr2'},
-    	far = {[1] = 'br3s', [3] = 'bl3s'},
-    	distant = {[1] = 'bl3s', [4] = 'tr2'},
-    	stress = {[1] = 'tr2', [2] = 'bl1', [4] = 'br1'},
-    },
+  ['bullseye'] = {
+    near = {[1] = 'k4', [2] = 'bl3s', [3] = 'br3s', [4] = 's1', [5] = 'tl2', [6] = 'tr2'},
+    far = {[1] = 's1', [3] = 's2', [6] = 's3'},
+    distant = {[1] = 's3', [2] = 's4'},
+    stress = {[1] = 's1', [4] = 's2', [6] = 's3'},
+  },
+  ['front_right'] = {
+    near = {[1] = 'k4', [2] = 'bl3s', [4] = 'br1', [5] = 'tl2', [6] = 'bl3'},
+    far = {[1] = 'br1', [3] = 's1', [4] = 'br2', [6] = 's2'},
+    distant = {[1] = 'br3', [5] = 's4'},
+    stress = {[1] = 's1', [2] = 'bl1', [3] = 'br1', [5] = 's2', [6] = 's3'},
+  },
+  ['right_front'] = {
+    near = {[1] = 'bl3s', [3] = 'bl1', [4] = 'bl2', [5] = 'tr2', [6] = 'tl2'},
+    far = {[1] = 'br1', [2] = 'tr2', [4] = 'br2', [5] = 'tr3'},
+    distant = {[1] = 'tr2', [3] = 'br3', [4] = 'tr3'},
+    stress = {[1] = 'bl1', [4] = 'br1', [6] = 's3'},
+  },
+  ['right_back'] = {
+    near = {[1] = 'k4', [2] = 'bl3s', [4] = 'bl1', [5] = 'tl2', [6] = 'tr2'},
+    far = {[1] = 'k4', [2] = 'bl3s', [4] = 'bl1', [5] = 'tr2'},
+    distant = {[1] = 'bl3s', [3] = 'tr2', [5] = 'tr3'},
+    stress = {[1] = 'bl1', [3] = 'br1', [4] = 's1', [5] = 's2', [6] = 's3'},
+  },
+  ['back_right'] = {
+    near = {[1] = 'k4', [2] = 'br3s', [3] = 'bl3s', [5] = 'bl1', [6] = 's1'},
+    far = {[1] = 'k4', [2] = 'bl3s', [4] = 'bl1', [5] = 'tr2', [6] = 'tr3'},
+    distant = {[1] = 'bl3s', [3] = 'tr2', [5] = 'tr3'},
+    stress = {[1] = 'bl1', [3] = 'br1', [4] = 's1', [5] = 's2', [6] = 's3'},
+  },
 }
+
 BehaviourDB.rule_sets[1].ships['customizedyt1300lightfreighter'].action_selection = {
   [1] = { --  manual Rotate prompt
       pass_through = true,
@@ -2999,34 +3000,34 @@ BehaviourDB.rule_sets[1].ships['aggressorassaultfighter'] = {}
 BehaviourDB.rule_sets[1].ships['aggressorassaultfighter'].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
 BehaviourDB.rule_sets[1].ships['aggressorassaultfighter'].move_table = {
     bullseye = {
-      near = {[1] = 'k4', [3] = 's1', [5] = 's2'},
+      near = {[1] = 'k4', [3] = 'bl3s', [4] = 'br3s', [5] = 's1', [6] = 's2'},
       far = {[1] = 's1', [3] = 's2', [6] = 's3'},
       distant = {[1] = 's3', [2] = 's4'},
-      stress = {[1] = 'bl1', [2] = 'br1', [3] = 's2'},
+      stress = {[1] = 's1', [3] = 's2', [6] = 's3'},
     },
   	front_right = {
-      near = {[1] = 'k4', [3] = 'br1', [6] = 'br2'},
-      far = {[1] = 'br1', [3] = 'br2', [6] = 'br3'},
+      near = {[1] = 'k4', [3] = 'bl3s', [5] = 's1', [6] = 'br1'},
+      far = {[1] = 'br1', [3] = 's1', [4] = 'br2', [6] = 's2'},
       distant = {[1] = 'br3', [5] = 's3'},
-      stress = {[1] = 'br1', [3] = 'br2', [4] = 's2'},
+      stress = {[1] = 'br1', [2] = 's1', [3] = 'br2', [5] = 's2', [6] = 'br3'},
     },
     right_front = {
-      near = {[1] = 'k4', [2] = 'br3s', [4] = 'tr1'},
-      far = {[1] = 'br1', [2] = 'tr1', [3] = 'br2', [5] = 'tr2'},
-      distant = {[1] = 'tr1', [4] = 'tr2'},
-      stress = {[1] = 'br1', [3] = 'tr1', [4] = 'br2'},
+      near = {[1] = 'k4', [2] = 'bl3s', [5] = 'tr1'},
+      far = {[1] = 'br1', [2] = 'tr1', [4] = 'br2', [5] = 'tr2'},
+      distant = {[1] = 'tr1', [2] = 'br2', [3] = 'tr2', [6] = 'br3'},
+      stress = {[1] = 'br1', [3] = 'tr1', [4] = 'br2', [6] = 'br3'},
     },
     right_back = {
-      near = {[1] = 'br3s', [4] = 'br1', [5] = 'tr1'},
+      near = {[1] = 'k4', [3] = 'bl3s', [5] = 'tr1'},
       far = {[1] = 'k4', [2] = 'br3s', [5] = 'tr1'},
-      distant = {[1] = 'br3s', [4] = 'br1', [5] = 'tr1'},
-      stress = {[1] = 'br1', [3] = 'tr1', [4] = 'br2'},
+      distant = {[1] = 'k4', [2] = 'bl3s', [4] = 'tr1', [5] = 'tr2'},
+      stress = {[1] = 'br1', [3] = 'tr1', [4] = 'br2', [6] = 'bl3'},
     },
     back_right = {
-      near = {[1] = 'k4', [3] = 'br3s', [5] = 'tr1'},
+      near = {[1] = 'k4', [3] = 'br3s', [4] = 'bl3s', [6] = 'tr2'},
       far = {[1] = 'k4', [3] = 'bl3s', [4] = 'br3s', [6] = 'tr1'},
-      distant = {[1] = 'k4', [2] = 'br3s', [4] = 'tr1'},
-      stress = {[1] = 'br1', [4] = 'br2', [6] = 'tr2'},
+      distant = {[1] = 'k4', [2] = 'bl3s', [4] = 'tr1', [6] = 'tr2'},
+      stress = {[1] = 'br1', [3] = 'br2', [5] = 'br3', [6] = 'bl3'},
     },
 }
 BehaviourDB.rule_sets[1].ships['aggressorassaultfighter'].action_selection = {
@@ -3078,35 +3079,35 @@ BehaviourDB.rule_sets[1].ships['aggressorassaultfighter'].action_selection = {
 BehaviourDB.rule_sets[1].ships['escapecraft'] = {}
 BehaviourDB.rule_sets[1].ships['escapecraft'].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
 BehaviourDB.rule_sets[1].ships['escapecraft'].move_table = {
-  bullseye = {
-    near = {[1] = 'k4', [2] = 's0', [4] = 's1', [6] = 's2'},
+  ['bullseye'] = {
+    near = {[1] = 'k3', [2] = 's0', [4] = 's1', [6] = 's2'},
     far = {[1] = 's1', [2] = 's2', [5] = 's3'},
     distant = {[1] = 's2', [2] = 's3'},
     stress = {[1] = 's1', [4] = 's2'},
   },
-  front_right = {
-    near = {[1] = 'k4', [3] = 'br1', [6] = 'br2'},
-    far = {[1] = 'br1', [3] = 'br2', [5] = 'br3', [6] = 's3'},
+  ['front_right'] = {
+    near = {[1] = 'k3', [2] = 's0', [3] = 'br1', [5] = 's1', [6] = 'bl3'},
+    far = {[1] = 'br1', [2] = 'br2', [4] = 's2', [5] = 'br3', [6] = 's3'},
     distant = {[1] = 'br3', [5] = 's3'},
-    stress = {[1] = 'br1', [4] = 's1', [5] = 's2'},
+    stress = {[1] = 'br1', [3] = 's1', [5] = 's2'},
   },
-  right_front = {
-    near = {[1] = 'k4', [3] = 'br1', [5] = 'tr2'},
-    far = {[1] = 'br1', [2] = 'tr2', [3] = 'br2', [5] = 'tr2'},
-    distant = {[1] = 'br3', [3] = 'tr2'},
-    stress = {[1] = 'br1', [5] = 's1'},
+  ['right_front'] = {
+    near = {[1] = 'k3', [2] = 's0', [3] = 'br1', [5] = 't2'},
+    far = {[1] = 'br1', [3] = 'br2', [4] = 't2'},
+    distant = {[1] = 't2', [3] = 'br2', [4] = 'br3'},
+    stress = {[1] = 'br1', [6] = 's1'},
   },
-  right_back = {
-    near = {[1] = 's0', [2] = 'k4', [4] = 'br1', [5] = 'tr2'},
-    far = {[1] = 'k4', [5] = 'tr2'},
-    distant = {[1] = 'k4', [4] = 'tr2'},
+  ['right_back'] = {
+    near = {[1] = 'k3', [4] = 's0', [5] = 'br1', [6] = 't2'},
+    far = {[1] = 'k3', [3] = 'br1', [4] = 't2', [6] = 'br3'},
+    distant = {[1] = 'k3', [3] = 't2', [6] = 'br3'},
     stress = {[1] = 's1', [3] = 'br1'},
   },
-  back_right = {
-    near = {[1] = 's0', [2] = 'k4', [5] = 'tr2'},
-    far = {[1] = 'k4', [3] = 'tr2'},
-    distant = {[1] = 'k4', [3] = 'tr2'},
-    stress = {[1] = 'br1', [6] = 'tr2'},
+  ['back_right'] = {
+    near = {[1] = 'k3', [4] = 's0', [5] = 's2', [6] = 'bl3'},
+    far = {[1] = 'k3', [3] = 'br1', [4] = 't2', [6] = 'br3'},
+    distant = {[1] = 'k3', [3] = 'br1', [4] = 't2', [6] = 'br3'},
+    stress = {[1] = 'br1', [5] = 's1', [6] = 's2'},
   },
 }
 BehaviourDB.rule_sets[1].ships['escapecraft'].action_selection = {
@@ -3149,32 +3150,32 @@ BehaviourDB.rule_sets[1].ships['g1astarfighter'] = {}
 BehaviourDB.rule_sets[1].ships['g1astarfighter'].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
 BehaviourDB.rule_sets[1].ships['g1astarfighter'].move_table = {
   bullseye = {
-    near = {[1] = 's0', [3] = 'bl1', [4] = 'br1', [5] = 's1'},
+    near = {[1] = 's0', [3] = 'k4', [5] = 's1'},
     far = {[1] = 's1', [2] = 's2', [5] = 's3'},
-    distant = {[1] = 's3', [2] = 's4'},
+    distant = {[1] = 's3', [4] = 's4'},
     stress = {[1] = 's1', [4] = 's2'},
   },
   front_right = {
-    near = {[1] = 'k4', [3] = 'br1', [6] = 'br2'},
-    far = {[1] = 'br1', [4] = 'br2', [6] = 'br3'},
-    distant = {[1] = 'br2', [5] = 'br3'},
-    stress = {[1] = 'br1', [4] = 'br2', [5] = 's2'},
+    near = {[1] = 'k4', [4] = 's0', [5] = 'br1', [6] = 's1'},
+    far = {[1] = 'br1', [3] = 's1', [4] = 'br2', [6] = 's2'},
+    distant = {[1] = 'br2', [3] = 's3', [5] = 'br3'},
+    stress = {[1] = 's1', [3] = 'br1', [5] = 's2'},
   },
   right_front = {
-    near = {[1] = 'tr1', [3] = 'br1', [4] = 'tr2'},
+    near = {[1] = 's0', [2] = 'tr1', [4] = 'br1', [5] = 'tr2'},
     far = {[1] = 'br1', [2] = 'tr1', [3] = 'tr2', [6] = 'br2'},
-    distant = {[1] = 'tr2', [4] = 'br2'},
-    stress = {[1] = 'br1', [5] = 'tr2'},
+    distant = {[1] = 'tr2', [5] = 'br2', [6] = 'br3'},
+    stress = {[1] = 'br1', [6] = 'tr2'},
   },
   right_back = {
-    near = {[1] = 's0', [2] = 'k4', [3] = 'k2', [4] = 'br1', [5] = 'tr1', [6] = 'tr2'},
-    far = {[1] = 'k4', [2] = 'k2', [5] = 'tr2'},
+    near = {[1] = 'k4', [3] = 'k2', [5] = 'tr1', [6] = 'tr2'},
+    far = {[1] = 'k2', [4] = 'tr1', [6] = 'tr2'},
     distant = {[1] = 'k2', [3] = 'tr2'},
-    stress = {[1] = 'br1', [4] = 'tr2'},
+    stress = {[1] = 'br1', [5] = 's1', [6] = 'tr2'},
   },
   back_right = {
-    near = {[1] = 's0', [2] = 'k4', [3] = 'k2', [5] = 'tr2'},
-    far = {[1] = 'k4', [3] = 'k2'},
+    near = {[1] = 's0', [2] = 'k4', [3] = 'k2', [5] = 'tr2', [6] = 'tl2'},
+    far = {[1] = 'k4', [2] = 'k2', [5] = 'tr2'},
     distant = {[1] = 'k2', [4] = 'tr2'},
     stress = {[1] = 'br1', [5] = 's1', [6] = 's2'},
   },
@@ -3210,35 +3211,35 @@ BehaviourDB.rule_sets[1].ships['g1astarfighter'].action_selection = {
 BehaviourDB.rule_sets[1].ships['lancerclasspursuitcraft'] = {}
 BehaviourDB.rule_sets[1].ships['lancerclasspursuitcraft'].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
 BehaviourDB.rule_sets[1].ships['lancerclasspursuitcraft'].move_table = {
-  bullseye = {
-    near = {[1] = 'k5', [3] = 's1', [5] = 's2'},
-    far = {[1] = 's2', [4] = 's3'},
+  ['bullseye'] = {
+    near = {[1] = 'k5', [3] = 's1', [4] = 'tl3', [5] = 'tr3', [6] = 's4'},
+    far = {[1] = 's1', [2] = 's2', [5] = 's3'},
     distant = {[1] = 's4', [2] = 's5'},
-    stress = {[1] = 's2', [5] = 's3'},
+    stress = {[1] = 's2', [3] = 's3', [4] = 's4', [5] = 'tl3', [6] = 'tr3'},
   },
-  front_right = {
-    near = {[1] = 'k5', [3] = 'br1', [6] = 'br2'},
-    far = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
-    distant = {[1] = 'br3', [5] = 's4'},
-    stress = {[1] = 's2', [4] = 'br3', [6] = 's3'},
+  ['front_right'] = {
+    near = {[1] = 'k5', [3] = 'br1', [4] = 's1', [5] = 'bl3', [6] = 'tr3'},
+    far = {[1] = 'br1', [2] = 's1', [3] = 'br2', [5] = 's2', [6] = 'br3'},
+    distant = {[1] = 'br3', [5] = 's4', [6] = 's5'},
+    stress = {[1] = 's2', [3] = 'br3', [5] = 's3', [6] = 'tr3'},
   },
-  right_front = {
-    near = {[1] = 'k5', [4] = 'tr2', [5] = 'tr3'},
-    far = {[1] = 'br1', [2] = 'tr2', [3] = 'br2', [4] = 'br3', [5] = 'tr3'},
-    distant = {[1] = 'tr2', [4] = 'tr3'},
-    stress = {[1] = 's2', [2] = 'br3', [5] = 'tr3'},
+  ['right_front'] = {
+    near = {[1] = 'k5', [3] = 'br1', [4] = 'tr2', [5] = 'br3', [6] = 'tr3'},
+    far = {[1] = 'br1', [2] = 'tr2', [4] = 'br2', [5] = 'tr3'},
+    distant = {[1] = 'tr2', [2] = 'br3', [3] = 'tr3'},
+    stress = {[1] = 's2', [2] = 'br3', [4] = 'tr3'},
   },
-  right_back = {
+  ['right_back'] = {
     near = {[1] = 'k5', [4] = 'br1', [5] = 'tr2', [6] = 'tr3'},
-    far = {[1] = 'k5', [5] = 'tr2', [6] = 'tr3'},
-    distant = {[1] = 'k5', [4] = 'tr3'},
-    stress = {[1] = 's2', [3] = 'br3', [5] = 'tr3'},
+    far = {[1] = 'k5', [3] = 'tr2', [5] = 'tr3'},
+    distant = {[1] = 'k5', [2] = 'tr2', [3] = 'tr3'},
+    stress = {[1] = 's2', [2] = 'br3', [4] = 'tr3'},
   },
-  back_right = {
-    near = {[1] = 'k5', [5] = 'tr2', [6] = 'tr3'},
-    far = {[1] = 'k5', [4] = 'tr2', [5] = 'tr3'},
-    distant = {[1] = 'k5', [4] = 'tr3'},
-    stress = {[1] = 's2', [3] = 'bl3', [4] = 'br3', [5] = 'tr3'},
+  ['back_right'] = {
+    near = {[1] = 'k5', [3] = 'br1', [4] = 's1', [5] = 'tr2', [6] = 'tr3'},
+    far = {[1] = 'k5', [3] = 's1', [4] = 'tr2', [5] = 'tr3'},
+    distant = {[1] = 'k5', [3] = 'br3', [4] = 'tr3'},
+    stress = {[1] = 's2', [2] = 'br3', [4] = 'tl3', [5] = 'tr3'},
   },
 }
 BehaviourDB.rule_sets[1].ships['lancerclasspursuitcraft'].action_selection = {
@@ -3281,35 +3282,35 @@ BehaviourDB.rule_sets[1].ships['lancerclasspursuitcraft'].action_selection = {
 BehaviourDB.rule_sets[1].ships['m12lkimogilafighter'] = {}
 BehaviourDB.rule_sets[1].ships['m12lkimogilafighter'].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
 BehaviourDB.rule_sets[1].ships['m12lkimogilafighter'].move_table = {
-  bullseye = {
-    near = {[1] = 'k4', [3] = 's1', [5] = 's2'},
+  ['bullseye'] = {
+    near = {[1] = 'k4', [4] = 's1', [6] = 's2'},
     far = {[1] = 's1', [2] = 's2', [6] = 's3'},
     distant = {[1] = 's2', [2] = 's3'},
-    stress = {[1] = 's1', [4] = 's2'},
+    stress = {[1] = 's1', [3] = 's2', [6] = 's3'},
   },
-  front_right = {
-    near = {[1] = 'k4', [3] = 'br1', [6] = 'br2'},
-    far = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+  ['front_right'] = {
+    near = {[1] = 'k4', [3] = 'br1', [6] = 's1'},
+    far = {[1] = 'br1', [2] = 'br2', [4] = 's2', [5] = 'br3', [6] = 's3'},
     distant = {[1] = 'br3', [5] = 's3'},
     stress = {[1] = 's1', [3] = 'br2', [5] = 's2'},
   },
-  right_front = {
-    near = {[1] = 'k4', [4] = 'br1', [6] = 'tr1'},
-    far = {[1] = 'tr1', [2] = 'br1', [3] = 'br2', [5] = 'tr2', [6] = 'tr3'},
-    distant = {[1] = 'tr2', [4] = 'tr3'},
-    stress = {[1] = 'tr1', [2] = 'br2'},
+  ['right_front'] = {
+    near = {[1] = 'k4', [4] = 'br1', [5] = 'tr1'},
+    far = {[1] = 'br1', [2] = 'br2', [3] = 'tr2', [6] = 'tr3'},
+    distant = {[1] = 'tr2', [3] = 'br3', [4] = 'tr3'},
+    stress = {[1] = 's1', [2] = 'br2', [6] = 'tr2'},
   },
-  right_back = {
-    near = {[1] = 'k4', [4] = 'br1', [5] = 'tr1', [6] = 'tr2'},
-    far = {[1] = 'k4', [5] = 'tr2'},
-    distant = {[1] = 'k4', [4] = 'tr2', [5] = 'tr3'},
-    stress = {[1] = 'tr2', [2] = 'tr3', [3] = 'br2'},
+  ['right_back'] = {
+    near = {[1] = 'k4', [4] = 'tr1', [5] = 'br3', [6] = 'tl3'},
+    far = {[1] = 'k4', [3] = 'tr1', [5] = 'tr2'},
+    distant = {[1] = 'k4', [3] = 'tr2', [4] = 'tr3'},
+    stress = {[1] = 's1', [2] = 'br2', [6] = 'tr2'},
   },
-  back_right = {
-    near = {[1] = 'k4', [4] = 'tr1', [5] = 'tr2', [6] = 'tr3'},
-    far = {[1] = 'k4', [4] = 'tr2'},
-    distant = {[1] = 'k4', [5] = 'tr2', [6] = 'tr3'},
-    stress = {[1] = 'br2', [6] = 'tr2'},
+  ['back_right'] = {
+    near = {[1] = 'k4', [4] = 'tr1', [5] = 'tr3', [6] = 'tl3'},
+    far = {[1] = 'k4', [5] = 'tr3'},
+    distant = {[1] = 'k4', [3] = 'tr2', [5] = 'tr3'},
+    stress = {[1] = 'br2', [6] = 'tr3'},
   },
 }
 BehaviourDB.rule_sets[1].ships['m12lkimogilafighter'].action_selection = {
@@ -3348,37 +3349,38 @@ BehaviourDB.rule_sets[1].ships['m12lkimogilafighter'].action_selection = {
 BehaviourDB.rule_sets[1].ships['scurrgh6bomber'] = {}
 BehaviourDB.rule_sets[1].ships['scurrgh6bomber'].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
 BehaviourDB.rule_sets[1].ships['scurrgh6bomber'].move_table = {
-  bullseye = {
-    near = {[1] = 'tl3t', [2] = 'tr3t', [3] = 's1', [5] = 's2'},
+  ['bullseye'] = {
+    near = {[1] = 'tl3t', [2] = 'tr3t', [3] = 's1', [6] = 's2'},
     far = {[1] = 's1', [2] = 's2', [5] = 's3'},
-    distant = {[1] = 's3', [6] = 's4'},
+    distant = {[1] = 's3', [4] = 's4'},
     stress = {[1] = 's1', [4] = 's2'},
   },
-  front_right = {
-    near = {[1] = 'tr3t', [3] = 'br1', [5] = 'br2'},
-    far = {[1] = 'br1', [3] = 'br2', [5] = 'br3', [6] = 's3'},
-    distant = {[1] = 'br3', [5] = 's3', [6] = 's4'},
-    stress = {[1] = 'br1', [4] = 's1', [5] = 's2'},
+  ['front_right'] = {
+    near = {[1] = 'tr3t', [2] = 'br1', [4] = 's1', [5] = 'bl2', [6] = 'tl2'},
+    far = {[1] = 'br1', [3] = 'br2', [5] = 's2', [6] = 'br3'},
+    distant = {[1] = 'br3', [5] = 's3'},
+    stress = {[1] = 'br1', [3] = 's1', [5] = 's2'},
   },
-  right_front = {
-    near = {[1] = 'tr3t', [2] = 'bl1', [3] = 'br1', [5] = 's2'},
-    far = {[1] = 'br1', [3] = 'br2', [5] = 'tr2', [6] = 'tr3'},
-    distant = {[1] = 'tr2', [3] = 'br3', [5] = 'tr3'},
-    stress = {[1] = 'br1', [5] = 's1'},
+  ['right_front'] = {
+    near = {[1] = 'tr3t', [3] = 'bl1', [5] = 'br1', [6] = 'tr2'},
+    far = {[1] = 'br1', [2] = 'br2', [3] = 'tr2', [6] = 'tr3'},
+    distant = {[1] = 'br2', [2] = 'tr2', [4] = 'br3', [5] = 'tr3'},
+    stress = {[1] = 'bl1', [3] = 'br1', [5] = 's1'},
   },
-  right_back = {
-    near = {[1] = 'tr3t', [4] = 'br1', [5] = 'tr2'},
+  ['right_back'] = {
+    near = {[1] = 'tr3t', [5] = 'bl1', [6] = 'tr2'},
     far = {[1] = 'tr3t', [5] = 'tr2'},
-    distant = {[1] = 'tr3t', [4] = 'tr2', [6] = 'tr3'},
+    distant = {[1] = 'tr3t', [3] = 'tr2', [6] = 'tr3'},
     stress = {[1] = 's1', [3] = 'bl1', [5] = 'br1'},
   },
-  back_right = {
-    near = {[1] = 'tr3t', [3] = 's1', [5] = 'br1'},
-    far = {[1] = 'tr3t', [5] = 's1', [6] = 'br1'},
-    distant = {[1] = 'tr3t', [4] = 'tr2'},
-    stress = {[1] = 'br1', [5] = 's2', [6] = 'tr2'},
+  ['back_right'] = {
+    near = {[1] = 'tl3t', [2] = 'tr3t', [4] = 's1', [5] = 'bl1', [6] = 'br1'},
+    far = {[1] = 'tr3t', [5] = 'tr2', [6] = 'tr3'},
+    distant = {[1] = 'tr3t', [3] = 'tr2'},
+    stress = {[1] = 'bl1', [3] = 'br1', [5] = 's1', [6] = 's2'},
   },
 }
+
 BehaviourDB.rule_sets[1].ships['scurrgh6bomber'].action_selection = {
   [1] = { -- (target not moved) Target lock if not in target's arc
       description = {text = "%s target locked %s.", strings = {'ship', 'target'}},
@@ -3411,35 +3413,35 @@ BehaviourDB.rule_sets[1].ships['scurrgh6bomber'].action_selection = {
 BehaviourDB.rule_sets[1].ships['yv666lightfreighter'] = {}
 BehaviourDB.rule_sets[1].ships['yv666lightfreighter'].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
 BehaviourDB.rule_sets[1].ships['yv666lightfreighter'].move_table = {
-  bullseye = {
-    near = {[1] = 's0', [4] = 'bl1', [5] = 'br1', [6] = 's1'},
-    far = {[1] = 's1', [2] = 's2', [5] = 's3'},
+  ['bullseye'] = {
+    near = {[1] = 's0', [3] = 'bl1', [4] = 'br1', [5] = 's1'}
+    ,far = {[1] = 's1', [3] = 's2', [6] = 's3'},
     distant = {[1] = 's3', [2] = 's4'},
-    stress = {[1] = 's1', [4] = 's2'},
+    stress = {[1] = 's1', [3] = 's2', [6] = 's3'},
   },
-  front_right = {
-    near = {[1] = 's0', [3] = 's1', [5] = 'br1', [6] = 'tr2'},
-    far = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+  ['front_right'] = {
+    near = {[1] = 's0', [3] = 's1', [5] = 'br1', [6] = 's2'},
+    far = {[1] = 'br1', [2] = 's1', [3] = 'br2', [5] = 's2', [6] = 's3'},
     distant = {[1] = 'br3', [5] = 's4'},
-    stress = {[1] = 'br1', [3] = 'br2', [4] = 's2'},
+    stress = {[1] = 's1', [2] = 'br1', [4] = 's2', [6] = 's3'},
   },
-  right_front = {
-    near = {[1] = 's0', [2] = 'br1', [5] = 'br2', [6] = 'tr2'},
-    far = {[1] = 'br1', [3] = 'br2', [6] = 'tr3'},
+  ['right_front'] = {
+    near = {[1] = 's0', [3] = 'br1', [5] = 'br2', [6] = 'tr2'},
+    far = {[1] = 'br1', [3] = 'br2', [5] = 'tr2', [6] = 'tr3'},
     distant = {[1] = 'tr2', [2] = 'br3', [4] = 'tr3'},
-    stress = {[1] = 'br1', [6] = 's1'},
+    stress = {[1] = 'br1', [5] = 's1'},
   },
-  right_back = {
-    near = {[1] = 's0', [3] = 'br1', [6] = 'tr2'},
-    far = {[1] = 'br1', [4] = 'tr2', [5] = 'br2', [6] = 'tr3'},
-    distant = {[1] = 'br1', [3] = 'tr2', [4] = 'tr3'},
+  ['right_back'] = {
+    near = {[1] = 's0', [2] = 'br1', [4] = 'tr2', [6] = 'tr3'},
+    far = {[1] = 'br1', [3] = 'tr2', [4] = 'tr3'},
+    distant = {[1] = 'br1', [3] = 'tr2', [4] = 'br3', [5] = 'tr3'},
     stress = {[1] = 'br1', [6] = 'tr3'},
   },
-  back_right = {
-    near = {[1] = 's0', [3] = 'br1', [5] = 'tr2', [6] = 'tr3'},
-    far = {[1] = 'br1', [4] = 'tr2', [5] = 'tr3'},
-    distant = {[1] = 'br1', [5] = 'tr2', [6] = 'tr3'},
-    stress = {[1] = 'br1', [5] = 's1', [6] = 'tr3'},
+  ['back_right'] = {
+    near = {[1] = 's0', [2] = 'br1', [5] = 'tl3', [6] = 'tr3'},
+    far = {[1] = 'br1', [3] = 'tr2', [5] = 'tr3'},
+    distant = {[1] = 'br1', [4] = 'tr2', [5] = 'tr3'},
+    stress = {[1] = 'br1', [5] = 's3', [6] = 'tr3'},
   },
 }
 BehaviourDB.rule_sets[1].ships['yv666lightfreighter'].action_selection = {
@@ -3479,60 +3481,61 @@ BehaviourDB.rule_sets[1].ships['jumpmaster5000']= {}
 BehaviourDB.rule_sets[1].ships['jumpmaster5000'].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
 BehaviourDB.rule_sets[1].ships['jumpmaster5000'].move_table = {
   ['bullseye'] = {
-    ['near'] = {[1] = 'k4', [3] = 's1', [5] = 's2'},
-    ['far'] = {[1] = 's1', [3] = 's2', [6] = 's3'},
-    ['distant'] = {[1] = 's3', [2] = 's4'},
-    ['stress'] = {[1] = 'bl1', [2] = 's1', [3] = 's2'},
+    near = {[1] = 'k4', [3] = 'bl3s', [4] = 's1', [5] = 'tl2', [6] = 'bl3'},
+    far = {[1] = 's1', [3] = 's2', [6] = 's3'},
+    distant = {[1] = 's3', [2] = 's4'},
+    stress = {[1] = 's1', [2] = 'bl1', [3] = 's2', [4] = 'bl2', [5] = 's3', [6] = 'bl3'},
   },
   ['front_right'] = {
-    ['near'] = {[1] = 'k4', [3] = 'bl1', [5] = 'br1', [6] = 's1'},
-    ['far'] = {[1] = 'bl1', [2] = 's1', [3] = 'bl2', [4] = 's2', [5] = 'br2', [6] = 's3'},
-    ['distant'] = {[1] = 'bl3', [4] = 'br3', [5] = 's3'},
-    ['stress'] = {[1] = 'bl1', [3] = 's1', [4] = 'bl2', [5] = 's2'},
+    near = {[1] = 'k4', [2] = 'bl3s', [4] = 'br1', [5] = 's1', [6] = 'tl2'},
+    far = {[1] = 'br1', [3] = 's1', [4] = 'br2', [5] = 'bl2', [6] = 's2'},
+    distant = {[1] = 'bl3', [2] = 'br3', [5] = 's3', [6] = 's4'},
+    stress = {[1] = 'bl1', [2] = 's1', [4] = 'bl2', [5] = 's2', [6] = 's3'},
   },
   ['right_front'] = {
-    ['near'] = {[1] = 'k4', [2] = 'bl3s', [4] = 'tl1', [6] = 'tr1'},
-    ['far'] = {[1] = 'bl1', [2] = 'tl1', [3] = 'bl2', [4] = 'br2', [5] = 'tl2', [6] = 'tr2'},
-    ['distant'] = {[1] = 'tl1', [3] = 'tr1', [4] = 'tl2', [6] = 'tr2'},
-    ['stress'] = {[1] = 'bl1', [3] = 's1', [4] = 'bl2', [6] = 's2'},
+    near = {[1] = 'k4', [2] = 'bl3s', [4] = 'bl1', [5] = 's1', [6] = 'tr1'},
+    far = {[1] = 'br1', [3] = 'tr1', [4] = 'br2', [6] = 'tr2'},
+    distant = {[1] = 'tr1', [2] = 'br2', [4] = 'tr2', [5] = 'br3'},
+    stress = {[1] = 'bl1', [2] = 's1', [4] = 'br2', [5] = 's2'},
   },
   ['right_back'] = {
-    ['near'] = {[1] = 'bl3s', [4] = 'bl1', [5] = 'tl1', [6] = 'tr1'},
-    ['far'] = {[1] = 'k4', [2] = 'bl3s', [5] = 'tl1', [6] = 'tr1'},
-    ['distant'] = {[1] = 'bl3s', [4] = 'br1', [5] = 'tl1', [6] = 'tr1'},
-    ['stress'] = {[1] = 'bl1', [3] = 's1', [4] = 'bl2', [6] = 's2'},
+    near = {[1] = 'k4', [2] = 'bl3s', [4] = 'bl1', [5] = 'br1', [6] = 'br2'},
+    far = {[1] = 'k4', [2] = 'bl3s', [5] = 'br1', [6] = 'tr1'},
+    distant = {[1] = 'bl3s', [4] = 'tr1', [5] = 'tr2', [6] = 'br3'},
+    stress = {[1] = 'bl1', [3] = 's1', [5] = 'bl2', [6] = 's2'},
   },
   ['back_right'] = {
-    ['near'] = {[1] = 'k4', [3] = 'bl3s', [5] = 'tl1', [6] = 'tl2'},
-    ['far'] = {[1] = 'k4', [3] = 'bl3s'},
-    ['distant'] = {[1] = 'k4', [2] = 'bl3s', [4] = 'tl1', [6] = 'tr1'},
-    ['stress'] = {[1] = 'bl1', [3] = 's1', [4] = 'bl2', [6] = 's2'},
+    near = {[1] = 'k4', [2] = 'bl3s', [4] = 's1', [5] = 'tl1', [6] = 'tl2'},
+    far = {[1] = 'k4', [3] = 'bl3s', [5] = 's1', [6] = 'tl2'},
+    distant = {[1] = 'k4', [2] = 'bl3s', [4] = 'tl1', [5] = 'tr1', [6] = 'tl2'},
+    stress = {[1] = 'bl1', [2] = 's1', [4] = 'bl2', [5] = 's2', [6] = 'bl3'},
   },
   ['front_left'] = {
-    ['near'] = {[1] = 'k4', [3] = 'br1', [5] = 'bl1', [6] = 's1'},
-    ['far'] = {[1] = 'br1', [2] = 's1', [3] = 'br2', [4] = 's2', [5] = 'bl2', [6] = 's3'},
-    ['distant'] = {[1] = 'br3', [4] = 'bl3', [5] = 's3'},
-    ['stress'] = {[1] = 'bl1', [3] = 's1', [4] = 'bl2', [5] = 's2'},
+    near = {[1] = 'k4', [2] = 'bl3s', [4] = 'bl1', [5] = 's1', [6] = 'tl2'},
+    far = {[1] = 'bl1', [3] = 's1', [4] = 'bl2', [6] = 's2'},
+    distant = {[1] = 'bl3', [5] = 's3', [6] = 's4'},
+    stress = {[1] = 'bl1', [3] = 's1', [4] = 'bl2', [5] = 's2', [6] = 's3'},
   },
   ['left_front'] = {
-    ['near'] = {[1] = 'k4', [2] = 'bl3s', [4] = 'bl1', [6] = 'tl1'},
-    ['far'] = {[1] = 'br1', [2] = 'tl1', [4] = 'bl1', [5] = 'bl2', [6] = 'tl2'},
-    ['distant'] = {[1] = 'tl1', [3] = 'bl1', [5] = 'tl2'},
-    ['stress'] = {[1] = 'bl1', [3] = 's1', [4] = 'bl2', [6] = 's2'},
+    near = {[1] = 'k4', [3] = 'bl1', [4] = 'bl2', [5] = 's1', [6] = 'tl1'},
+    far = {[1] = 'bl1', [2] = 'tr1', [4] = 'bl2', [5] = 'tr2'},
+    distant = {[1] = 'bl2', [2] = 'tl2', [6] = 'bl3'},
+    stress = {[1] = 'bl1', [2] = 'bl2', [5] = 'tl2', [6] = 'bl3'},
   },
   ['left_back'] = {
-    ['near'] = {[1] = 'bl3s', [4] = 'br1', [5] = 'tl1'},
-    ['far'] = {[1] = 'k4', [2] = 'bl3s', [5] = 'tl1'},
-    ['distant'] = {[1] = 'bl3s', [4] = 'bl1', [5] = 'tl1'},
-    ['stress'] = {[1] = 'bl1', [3] = 's1', [4] = 'bl2', [6] = 's2'},
-  },
+    near = {[1] = 'k4', [3] = 'bl3s', [4] = 'bl1', [6] = 'tl1'},
+    far = {[1] = 'k4', [3] = 'tl1', [5] = 'tl2'},
+    distant = {[1] = 'tl1', [2] = 'bl2', [3] = 'tl2', [6] = 'bl3'},
+    stress = {[1] = 'bl1', [3] = 'bl2', [5] = 'bl3'},
+},
   ['back_left'] = {
-    ['near'] = {[1] = 'k4', [3] = 'bl3s', [5] = 'tl1', [6] = 'tl2'},
-    ['far'] = {[1] = 'k4', [3] = 'bl3s'},
-    ['distant'] = {[1] = 'k4', [2] = 'bl3s', [4] = 'tl1'},
-    ['stress'] = {[1] = 'bl1', [3] = 's1', [4] = 'bl2', [6] = 's2'},
+    near = {[1] = 'k4', [3] = 'bl3s', [5] = 'tl1', [6] = 'tl2'},
+    far = {[1] = 'k4', [2] = 'bl3s', [3] = 'tl1', [5] = 'tl2'},
+    distant = {[1] = 'k4', [2] = 'bl3s', [3] = 'tl1', [6] = 'tl2'},
+    stress = {[1] = 'bl1', [4] = 's1', [5] = 'bl2'},
   },
 }
+
 BehaviourDB.rule_sets[1].ships['jumpmaster5000'].action_selection = {
   [1] = { -- Target lock
       ['description'] = {['text'] = "%s target locked %s. If %s can get a shot by rotating, then perform a red Rotate action.", ['strings'] = {'ship', 'target', 'ship'}},
@@ -3567,34 +3570,34 @@ BehaviourDB.rule_sets[1].ships['quadrijettransferspacetug'] = {}
 BehaviourDB.rule_sets[1].ships['quadrijettransferspacetug'].target_selection = {[1]='ClosestInArc', [2]='Closest'}
 BehaviourDB.rule_sets[1].ships['quadrijettransferspacetug'].move_table = {
   ['bullseye'] = {
-    ['near'] = {[1] = 's2r', [2] = 'bl1r', [3] = 'br1r', [4] = 's1', [6] = 's2'},
-    ['far'] = {[1] = 's2r', [2] = 's1', [3] = 's2', [6] = 's3'},
-    ['distant'] = {[1] = 's2', [2] = 's3'},
-    ['stress'] = {[1] = 'bl2', [3] = 'br2', [5] = 's2'},
+    near = {[1] = 'bl2s', [2] = 'br2s', [3] = 's2r', [4] = 'bl1r', [5] = 'br1r', [6] = 's1'},
+    far = {[1] = 's1', [3] = 's2', [6] = 's3'},
+    distant = {[1] = 's2', [2] = 's3'},
+    stress = {[1] = 'bl2', [2] = 'br2', [3] = 's2', [6] = 's3'},
   },
   ['front_right'] = {
-    ['near'] = {[1] = 'bl1r', [3] = 'br1', [5] = 's1', [6] = 'tr1'},
-    ['far'] = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
-    ['distant'] = {[1] = 'br3', [5] = 's3'},
-    ['stress'] = {[1] = 'br2', [4] = 's2', [6] = 's3'},
+    near = {[1] = 's2r', [2] = 'bl1r', [4] = 's1', [5] = 'br1'},
+    far = {[1] = 'br2', [3] = 's2', [4] = 'br3', [6] = 's3'},
+    distant = {[1] = 'br3', [5] = 's3'},
+    stress = {[1] = 'br2', [4] = 's2', [6] = 's3'},
   },
   ['right_front'] = {
-    ['near'] = {[1] = 'bl1r', [2] = 'bl2s', [3] = 'br1', [5] = 'tr1', [6] = 'tr3'},
-    ['far'] = {[1] = 'br1', [2] = 'tr1', [3] = 'br2', [6] = 'tr3'},
-    ['distant'] = {[1] = 'tr1', [2] = 'tr3', [3] = 'br2', [5] = 'br3'},
-    ['stress'] = {[1] = 'br2', [5] = 's2'},
+    near = {[1] = 'bl2s', [2] = 'bl1r', [3] = 'br1', [4] = 'tr1', [6] = 'tr2'},
+    far = {[1] = 'br1', [2] = 'tr1', [3] = 'br2', [4] = 'tr2'},
+    distant = {[1] = 'tr1', [2] = 'tr2', [5] = 'br3'},
+    stress = {[1] = 'br2', [5] = 's2', [6] = 'tr1'},
   },
   ['right_back'] = {
-    ['near'] = {[1] = 'bl1r', [2] = 'bl2s', [4] = 'br1', [6] = 'tr1'},
-    ['far'] = {[1] = 'bl2s', [4] = 'br1', [5] = 'tr1'},
-    ['distant'] = {[1] = 'bl2s', [4] = 'br2', [5] = 'tr1'},
-    ['stress'] = {[1] = 's2', [3] = 'br2'},
+    near = {[1] = 'bl2s', [3] = 's2r', [4] = 'bl1r', [5] = 'tr1'},
+    far = {[1] = 'bl2s', [3] = 'tr1', [6] = 'tr2'},
+    distant = {[1] = 'bl2s', [3] = 'tr1', [4] = 'tr2'},
+    stress = {[1] = 's2', [3] = 'br2'},
   },
   ['back_right'] = {
-    ['near'] = {[1] = 's2r', [2] = 'bl1r', [3] = 'bl2s', [5] = 'br1', [6] = 'tr3'},
-    ['far'] = {[1] = 'bl2s', [5] = 'tr3'},
-    ['distant'] = {[1] = 'bl2s', [4] = 'br1', [5] = 'tr1'},
-    ['stress'] = {[1] = 'br2', [5] = 's2'},
+    near = {[1] = 's2r', [2] = 'bl1r', [3] = 'br2s', [4] = 'bl2s', [6] = 'br3'},
+    far = {[1] = 'bl2s', [4] = 'tr1', [5] = 'tr2'},
+    distant = {[1] = 'bl2s', [3] = 'tr1', [6] = 'tr2'},
+    stress = {[1] = 'bl2', [2] = 'br2', [4] = 's2', [6] = 's3'},
   },
 }
 BehaviourDB.rule_sets[1].ships['quadrijettransferspacetug'].action_selection = {

--- a/TTS_xwing/src/BehaviourDB.ttslua
+++ b/TTS_xwing/src/BehaviourDB.ttslua
@@ -3803,35 +3803,35 @@ BehaviourDB.rule_sets[1].ships['tiesffighter'].action_selection = {
 BehaviourDB.rule_sets[1].ships['tiesebomber'] = {}
 BehaviourDB.rule_sets[1].ships['tiesebomber'].target_selection = {[1]='LockedInRange', [2]='ClosestInArc', [3]='Closest'}
 BehaviourDB.rule_sets[1].ships['tiesebomber'].move_table = {
-  bullseye = {
-    near = {[1] = 'bl3s', [2] = 'br3s', [3] = 's1', [5] = 's2'},
-    far = {[1] = 's2', [5] = 's3'},
+  ['bullseye'] = {
+    near = {[1] = 'br3s', [2] = 'bl3s', [3] = 's1', [5] = 's2', [6] = 's4'},
+    far = {[1] = 's1', [2] = 's2', [5] = 's3'},
     distant = {[1] = 's3', [2] = 's4'},
-    stress = {[1] = 's1', [4] = 's2'},
+    stress = {[1] = 's1', [3] = 's2', [6] = 's3'},
   },
-  front_right = {
-    near = {[1] = 'bl3s', [3] = 'br1', [6] = 'br2'},
-    far = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+  ['front_right'] = {
+    near = {[1] = 'bl3s', [4] = 'br1', [5] = 's1', [6] = 'tl2'},
+    far = {[1] = 'br2', [3] = 's2', [4] = 'br3', [6] = 's3'},
     distant = {[1] = 'br3', [5] = 's4'},
     stress = {[1] = 's1', [3] = 's2', [5] = 's3'},
   },
-  right_front = {
-    near = {[1] = 'bl3s', [3] = 'br1', [4] = 'tr1', [5] = 'tr2'},
-    far = {[1] = 'tr1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
-    distant = {[1] = 'tr2', [3] = 'br3', [5] = 'tr3'},
-    stress = {[1] = 's1', [4] = 'br1', [5] = 's2', [6] = 'tr2'},
+  ['right_front'] = {
+    near = {[1] = 'bl3s', [3] = 'bl1', [4] = 'tr1', [6] = 'tr2'},
+    far = {[1] = 'br1', [2] = 'tr2', [4] = 'br2', [5] = 'tr3'},
+    distant = {[1] = 'tr2', [2] = 'br3', [4] = 'tr3'},
+    stress = {[1] = 's1', [4] = 's2', [5] = 'tr2', [6] = 'tr3'},
   },
-  right_back = {
-    near = {[1] = 'bl3s', [4] = 'br1', [5] = 'tr1', [6] = 'tr2'},
-    far = {[1] = 'br3s', [2] = 'bl3s', [5] = 'tr2'},
-    distant = {[1] = 'br3s', [4] = 'tr2', [6] = 'tr3'},
-    stress = {[1] = 's1', [5] = 'br1', [6] = 'tr2'},
+  ['right_back'] = {
+    near = {[1] = 'bl3s', [3] = 'bl1', [4] = 'tr1', [6] = 'tr3'},
+    far = {[1] = 'bl3s', [3] = 'tr1', [5] = 'tr2'},
+    distant = {[1] = 'bl3s', [3] = 'tr2', [4] = 'tr3'},
+    stress = {[1] = 's1', [5] = 's2', [6] = 'tr2'},
   },
-  back_right = {
-    near = {[1] = 'br3s', [3] = 'bl3s', [5] = 'br1', [6] = 'tr2'},
-    far = {[1] = 'br3s', [3] = 'bl3s', [6] = 'tr3'},
-    distant = {[1] = 'br3s', [4] = 'tr2'},
-    stress = {[1] = 's1', [3] = 'br1', [4] = 's2'},
+  ['back_right'] = {
+    near = {[1] = 'br3s', [2] = 'bl3s', [4] = 'bl1', [5] = 's1', [6] = 'tr3'},
+    far = {[1] = 'bl3s', [4] = 'tr2', [5] = 'tr3'},
+    distant = {[1] = 'bl3s', [3] = 'tr2', [6] = 'tr3'},
+    stress = {[1] = 's1', [4] = 'tr2', [5] = 's2', [6] = 'tr3'},
   },
 }
 BehaviourDB.rule_sets[1].ships['tiesebomber'].action_selection = {
@@ -3898,35 +3898,35 @@ BehaviourDB.rule_sets[1].ships['tiesebomber'].action_selection = {
 BehaviourDB.rule_sets[1].ships['tievnsilencer'] = {}
 BehaviourDB.rule_sets[1].ships['tievnsilencer'].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
 BehaviourDB.rule_sets[1].ships['tievnsilencer'].move_table = {
-  bullseye = {
-    near = {[1] = 'k4', [2] = 'tr3t', [4] = 'tl3t', [6] = 's2'},
-    far = {[1] = 's2', [3] = 's3'},
+  ['bullseye'] = {
+    near = {[1] = 'k4', [4] = 's2', [5] = 'tl3', [6] = 'tr3'},
+    far = {[1] = 's2', [4] = 's3'},
     distant = {[1] = 's4', [2] = 's5'},
-    stress = {[1] = 's2', [3] = 's3'},
+    stress = {[1] = 's2', [4] = 's3', [6] = 's4'},
   },
-  front_right = {
-    near = {[1] = 'tr3t', [4] = 'tr1', [5] = 'br2'},
-    far = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+  ['front_right'] = {
+    near = {[1] = 'br2', [2] = 's2', [4] = 'bl3', [5] = 'tl3', [6] = 's5'},
+    far = {[1] = 'br2', [3] = 's2', [4] = 'br3', [6] = 's3'},
     distant = {[1] = 'br3', [5] = 's4'},
-    stress = {[1] = 'tr2', [2] = 'br2', [5] = 's2'},
+    stress = {[1] = 'br2', [4] = 's2', [6] = 's3'},
   },
-  right_front = {
-    near = {[1] = 'k4', [2] = 'tr3t', [4] = 'tr1'},
-    far = {[1] = 'tr2', [3] = 'br2', [5] = 'tr3'},
-    distant = {[1] = 'tr2', [4] = 'tr3'},
-    stress = {[1] = 'tr2', [4] = 'br2', [6] = 'tr3'},
+  ['right_front'] = {
+    near = {[1] = 'k4', [2] = 'tr3r', [4] = 'tr1'},
+    far = {[1] = 'tr2', [4] = 'br2', [5] = 'tr3'},
+    distant = {[1] = 'tr2', [2] = 'br3', [4] = 'tr3'},
+    stress = {[1] = 'br2', [3] = 'tr2'},
   },
-  right_back = {
-    near = {[1] = 'tr3t', [4] = 'tr1', [5] = 'tr2'},
-    far = {[1] = 'tr3t', [4] = 'tr2'},
-    distant = {[1] = 'tr3t', [4] = 'tr1'},
-    stress = {[1] = 'tr1', [2] = 'tr2', [4] = 'br2'},
+  ['right_back'] = {
+    near = {[1] = 'k4', [2] = 'tr3r', [5] = 'tr1'},
+    far = {[1] = 'tr3r', [3] = 'tr1', [6] = 'tr2'},
+    distant = {[1] = 'tr3r', [3] = 'tr1', [4] = 'tr2', [6] = 'tr3'},
+    stress = {[1] = 'br2', [3] = 'tr2'},
   },
-  back_right = {
-    near = {[1] = 'k4', [3] = 'tr3t', [5] = 'tr2'},
-    far = {[1] = 'tr3t', [3] = 'tr2'},
-    distant = {[1] = 'tr3t', [4] = 'tr2'},
-    stress = {[1] = 'tr2', [5] = 'tr3', [6] = 's5'},
+  ['back_right'] = {
+    near = {[1] = 'k4', [3] = 'tl3t', [4] = 'tr3r', [6] = 'tr3'},
+    far = {[1] = 'k4', [2] = 'tr3r', [4] = 'tr2', [6] = 'tr3'},
+    distant = {[1] = 'tr3r', [3] = 'tr1', [6] = 'tr2'},
+    stress = {[1] = 'br2', [2] = 'tl2', [3] = 'tr2', [6] = 's5'},
   },
 }
 BehaviourDB.rule_sets[1].ships['tievnsilencer'].action_selection = {
@@ -3991,34 +3991,35 @@ BehaviourDB.rule_sets[1].ships['tievnsilencer'].action_selection = {
 BehaviourDB.rule_sets[1].ships['tiewiwhispermodifiedinterceptor'] = {}
 BehaviourDB.rule_sets[1].ships['tiewiwhispermodifiedinterceptor'].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
 BehaviourDB.rule_sets[1].ships['tiewiwhispermodifiedinterceptor'].move_table = {
-  bullseye = {
-    near = {[1] = 'k5', [2] = 'k4', [3] = 'bl2', [4] = 'br2', [5] = 's2'},
-    far = {[1] = 's2', [5] = 's3'},distant = {[1] = 's4', [2] = 's5'},
-    stress = {[1] = 'bl2', [3] = 'br2', [5] = 's2'},
+  ['bullseye'] = {
+    near = {[1] = 'k5', [3] = 'bl3s', [4] = 'br3s', [5] = 'tl3', [6] = 'tr3'},
+    far = {[1] = 's2', [5] = 's3'},
+    distant = {[1] = 's4', [2] = 's5'},
+    stress = {[1] = 'bl3', [2] = 'br3', [3] = 's2', [4] = 's3', [5] = 's4', [6] = 's5'},
   },
-  front_right = {
-    near = {[1] = 'k5', [2] = 'bl3s', [3] = 'tr1', [5] = 'br2'},
-    far = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+  ['front_right'] = {
+    near = {[1] = 'k5', [2] = 'bl3s', [4] = 'br2', [5] = 's2', [6] = 'tl2'},
+    far = {[1] = 'br2', [3] = 's2', [4] = 'br3', [6] = 's3'},
     distant = {[1] = 'br3', [5] = 's4'},
-    stress = {[1] = 'br2', [4] = 's2', [6] = 's3'},
+    stress = {[1] = 'br2', [3] = 's2', [4] = 'br3', [5] = 's3', [6] = 's4'},
   },
-  right_front = {
-    near = {[1] = 'k5', [2] = 'bl3s', [3] = 'tr1', [5] = 'bl2', [6] = 'tr2'},
-    far = {[1] = 'tr1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
-    distant = {[1] = 'tr2', [4] = 'tr3'},
-    stress = {[1] = 'tr1', [2] = 'br2', [5] = 'br3'},
+  ['right_front'] = {
+    near = {[1] = 'k5', [2] = 'bl3s', [4] = 'tl1', [5] = 'tr1', [6] = 'bl2'},
+    far = {[1] = 'tr2', [3] = 'br2', [4] = 'tr3'},
+    distant = {[1] = 'tr2', [2] = 'br3', [3] = 'tr3'},
+    stress = {[1] = 'bl2', [3] = 'br2', [5] = 'br3'},
   },
-  right_back = {
-    near = {[1] = 'k4', [2] = 'bl3s', [4] = 'tr1', [5] = 'br2'},
-    far = {[1] = 'k4', [2] = 'br3s', [3] = 'bl3s', [4] = 'tr1', [5] = 'tr2', [6] = 'br2'},
-    distant = {[1] = 'k4', [2] = 'br3s', [3] = 'bl3s', [4] = 'tr1'},
-    stress = {[1] = 'tr1', [2] = 'tr2', [3] = 'bl2', [5] = 'br2'},
+  ['right_back'] = {
+    near = {[1] = 'k4', [2] = 'bl3s', [4] = 'tr1', [5] = 's2', [6] = 'bl2'},
+    far = {[1] = 'k4', [2] = 'bl3s', [4] = 'tr2', [5] = 'tr3'},
+    distant = {[1] = 'k4', [2] = 'bl3s', [3] = 'tr1', [6] = 'tr2'},
+    stress = {[1] = 'bl2', [3] = 'br2', [5] = 'br3'},
   },
-  back_right = {
-    near = {[1] = 'k5', [2] = 'k4', [3] = 'br3s', [4] = 'bl3s', [5] = 'br2'},
-    far = {[1] = 'k4', [2] = 'br3s', [3] = 'bl3s', [4] = 'br2', [5] = 'tr2', [6] = 'tr3'},
-    distant = {[1] = 'k4', [3] = 'br3s', [4] = 'bl3s', [5] = 'tr1'},
-    stress = {[1] = 'br2', [5] = 's2'},
+  ['back_right'] = {
+    near = {[1] = 'k4', [2] = 'br3s', [3] = 'bl3s', [5] = 's2', [6] = 'bl2'},
+    far = {[1] = 'k4', [2] = 'bl3s', [4] = 'tr2', [5] = 'tr3'},
+    distant = {[1] = 'k4', [2] = 'bl3s', [3] = 'tr1', [6] = 'tr2'},
+    stress = {[1] = 'bl2', [3] = 'br2', [5] = 's2'},
   },
 }
 BehaviourDB.rule_sets[1].ships['tiewiwhispermodifiedinterceptor'].action_selection = {
@@ -4081,35 +4082,35 @@ BehaviourDB.rule_sets[1].ships['upsilonclasscommandshuttle'] = {}
 BehaviourDB.rule_sets[1].ships['upsilonclasscommandshuttle'].target_selection = {[1]='ClosestInArc', [2]='Closest'}
 BehaviourDB.rule_sets[1].ships['upsilonclasscommandshuttle'].action_selection = {}
 BehaviourDB.rule_sets[1].ships['upsilonclasscommandshuttle'].move_table = {
-  bullseye = {
-    near = {[1] = 's0', [2] = 'bl1', [3] = 'br1', [4] = 's1', [6] = 's2'},
-    far = {[1] = 's1', [2] = 's2', [5] = 's3'},
+  ['bullseye'] = {
+    near = {[1] = 's0', [3] = 's1', [6] = 's2'},
+    far = {[1] = 's1', [3] = 's2', [6] = 's3'},
     distant = {[1] = 's2', [2] = 's3'},
     stress = {[1] = 's1', [4] = 's2'},
   },
-  front_right = {
-    near = {[1] = 's0', [3] = 'br1', [6] = 'br2'},
-    far = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+  ['front_right'] = {
+    near = {[1] = 's0', [3] = 'br1', [4] = 's1', [5] = 'tl2', [6] = 'bl3'},
+    far = {[1] = 'br1', [2] = 's1', [3] = 'br2', [5] = 's2', [6] = 'br3'},
     distant = {[1] = 'br3', [5] = 's3'},
     stress = {[1] = 's1', [3] = 'br2', [5] = 's2'},
   },
-  right_front = {
-    near = {[1] = 's0', [3] = 'br1', [5] = 'tr1', [6] = 'tr2'},
-    far = {[1] = 'br1', [2] = 'tr1', [3] = 'br2', [5] = 'tr2'},
+  ['right_front'] = {
+    near = {[1] = 's0', [2] = 'br1', [3] = 'tr1', [6] = 'tr2'},
+    far = {[1] = 'br1', [2] = 'br2', [3] = 'tr2', [6] = 'tr3'},
     distant = {[1] = 'tr2', [4] = 'br3', [5] = 'tr3'},
-    stress = {[1] = 's1', [3] = 'br2', [5] = 's2', [6] = 'tr2'},
-  },
-  right_back = {
-    near = {[1] = 's0', [4] = 'br1', [5] = 'tr2'},
-    far = {[1] = 's0', [3] = 'br1', [4] = 'tr1', [5] = 'tr2'},
-    distant = {[1] = 's0', [3] = 'tr2', [6] = 'tr3'},
     stress = {[1] = 's1', [3] = 'br2', [6] = 'tr2'},
   },
-  back_right = {
-    near = {[1] = 's0', [3] = 'tr1', [4] = 'br1', [5] = 'tr2'},
-    far = {[1] = 's0', [2] = 'tr1', [3] = 'tr2'},
-    distant = {[1] = 's0', [2] = 'tr1', [3] = 'tr2'},
-    stress = {[1] = 's1', [2] = 'br2', [6] = 'tr2'},
+  ['right_back'] = {
+    near = {[1] = 's0', [3] = 'tr1', [4] = 'br1', [5] = 'tl2', [6] = 'bl3'},
+    far = {[1] = 'br1', [2] = 'tr1', [5] = 'tr2'},
+    distant = {[1] = 'br2', [2] = 'tr2', [5] = 'br3', [6] = 'tr3'},
+    stress = {[1] = 's1', [3] = 'br2', [6] = 'tr2'},
+  },
+  ['back_right'] = {
+    near = {[1] = 's0', [2] = 's2', [3] = 'tl2', [4] = 'tr2', [5] = 'bl3', [6] = 'br3'},
+    far = {[1] = 'tr1', [2] = 'tr2', [6] = 'tr3'},
+    distant = {[1] = 'tr1', [2] = 'tr2', [6] = 'tr3'},
+    stress = {[1] = 's2', [3] = 'br2', [6] = 'tr2'},
   },
 }
 BehaviourDB.rule_sets[1].ships['upsilonclasscommandshuttle'].action_selection = {
@@ -4154,35 +4155,35 @@ BehaviourDB.rule_sets[1].ships['xiclasslightshuttle'] = {}
 BehaviourDB.rule_sets[1].ships['xiclasslightshuttle'].target_selection = {[1]='ClosestInArc', [2]='Closest'}
 BehaviourDB.rule_sets[1].ships['xiclasslightshuttle'].action_selection = {}
 BehaviourDB.rule_sets[1].ships['xiclasslightshuttle'].move_table = {
-  bullseye = {
-    near = {[1] = 's0', [4] = 'bl1', [5] = 'br1', [6] = 's1'},
-    far = {[1] = 's1', [2] = 's2', [5] = 's3'},
+  ['bullseye'] = {
+    near = {[1] = 's0', [3] = 's1', [6] = 's2'},
+    far = {[1] = 's1', [3] = 's2', [6] = 's3'},
     distant = {[1] = 's3', [2] = 's4'},
     stress = {[1] = 's1', [4] = 's2'},
   },
-  front_right = {
-    near = {[1] = 's0', [3] = 's1', [5] = 'br1', [6] = 'tr2'},
-    far = {[1] = 'br2', [4] = 'br3', [6] = 's3'},
+  ['front_right'] = {
+    near = {[1] = 's0', [3] = 's1', [4] = 'br1', [6] = 'tl2'},
+    far = {[1] = 'br1', [2] = 'br2', [4] = 's2', [5] = 'br3', [6] = 's3'},
     distant = {[1] = 'br3', [5] = 's4'},
-    stress = {[1] = 'br1', [3] = 'br2', [4] = 's2'},
+    stress = {[1] = 'br1', [3] = 's1', [4] = 'br2', [6] = 's2'},
   },
-  right_front = {
-    near = {[1] = 's0', [2] = 'br1', [4] = 'br2', [5] = 'tr2'},
-    far = {[1] = 'br1', [2] = 'br2', [4] = 'tr2'},
-    distant = {[1] = 'br3', [3] = 'tr2', [5] = 'tr3'},
-    stress = {[1] = 'br1', [4] = 'br2', [6] = 'tr2'},
+  ['right_front'] = {
+    near = {[1] = 's0', [2] = 'br1', [4] = 'tl2', [5] = 'tr2'},
+    far = {[1] = 'br1', [2] = 'br2', [3] = 'tr2', [6] = 'tr3'},
+    distant = {[1] = 'tr2', [3] = 'br3', [5] = 'tr3'},
+    stress = {[1] = 'br1', [3] = 's1', [4] = 'br2', [6] = 'tr2'},
   },
-  right_back = {
-    near = {[1] = 's0', [4] = 'br1', [5] = 'tr2'},
-    far = {[1] = 's0', [2] = 'br1', [4] = 'tr2'},
-    distant = {[1] = 's0', [3] = 'br1', [5] = 'tr2', [6] = 'tr3'},
-    stress = {[1] = 'br1', [4] = 'br2', [6] = 'tr2'},
+	['right_back'] = {
+    near = {[1] = 's0', [2] = 's1', [3] = 'tl2', [4] = 'tr2', [6] = 'bl3'},
+    far = {[1] = 'br1', [2] = 'br2', [3] = 'tr2', [6] = 'tr3'},
+    distant = {[1] = 'br2', [2] = 'br3', [3] = 'tr2', [5] = 'tr3'},
+    stress = {[1] = 'br1', [3] = 's1', [4] = 'br2', [6] = 'tr2'},
   },
-  back_right = {
-    near = {[1] = 's0', [4] = 'br1', [6] = 'tr2'},
-    far = {[1] = 's0', [2] = 'br1', [4] = 'tr2'},
-    distant = {[1] = 's0', [3] = 'br1', [5] = 'tr2'},
-    stress = {[1] = 'br1', [4] = 'br2', [5] = 's1', [6] = 'tr2'},
+  ['back_right'] = {
+    near = {[1] = 's0', [3] = 's1', [4] = 'tl2', [5] = 'tr2', [6] = 'br3'},
+    far = {[1] = 'br2', [2] = 'tr2', [5] = 'tr3'},
+    distant = {[1] = 'br2', [2] = 'tr2', [6] = 'tr3'},
+    stress = {[1] = 'br1', [2] = 's1', [3] = 'br2', [5] = 's2', [6] = 'tr2'},
   },
 }
 BehaviourDB.rule_sets[1].ships['xiclasslightshuttle'].action_selection = {
@@ -4217,34 +4218,34 @@ BehaviourDB.rule_sets[1].ships['tiebainterceptor'] = {}
 BehaviourDB.rule_sets[1].ships['tiebainterceptor'].target_selection = {[1]='LockedInRange', [2]='ClosestInArcLowerInitiative', [3]='ClosestInArc', [4]='Closest'}
 BehaviourDB.rule_sets[1].ships['tiebainterceptor'].move_table = {
   ['bullseye'] = {
-    ['near'] = {[1] = 'k5', [3] = 'br2s', [4] = 'bl2s', [5] = 's2'},
-    ['far'] = {[1] = 's2', [4] = 's3'},
-    ['distant'] = {[1] = 's4', [2] = 's5'},
-    ['stress'] = {[1] = 'bl1', [2] = 'br1', [3] = 'bl2', [4] = 'br2', [5] = 's2'},
+    near = {[1] = 'k5', [3] = 'bl2s', [4] = 'br2s', [5] = 's2'},
+    far = {[1] = 's2', [5] = 's3'},
+    distant = {[1] = 's4', [2] = 's5'},
+    stress = {[1] = 's2', [4] = 's3', [6] = 's4'},
   },
   ['front_right'] = {
-    ['near'] = {[1] = 'k5', [3] = 'br1', [6] = 'br2'},
-    ['far'] = {[1] = 'br1', [3] = 'br2', [6] = 'br3'},
-    ['distant'] = {[1] = 'br3', [5] = 's4'},
-    ['stress'] = {[1] = 'br1', [3] = 'br2', [4] = 's2', [6] = 's3'},
+    near = {[1] = 'k5', [3] = 'bl2s', [4] = 'br1', [6] = 'br2'},
+    far = {[1] = 'br1', [2] = 's2', [3] = 'br2', [5] = 's3', [6] = 'br3'},
+    distant = {[1] = 'br3', [5] = 's4'},
+    stress = {[1] = 'br1', [3] = 'br2', [5] = 's2', [6] = 's3'},
   },
   ['right_front'] = {
-    ['near'] = {[1] = 'k5', [2] = 'bl2s', [4] = 'tr1'},
-    ['far'] = {[1] = 'br1', [2] = 'tr2', [3] = 'br2', [5] = 'tr3'},
-    ['distant'] = {[1] = 'tr2', [4] = 'tr3'},
-    ['stress'] = {[1] = 'br1', [3] = 'br2', [5] = 'tr1'},
+    near = {[1] = 'k5', [3] = 'bl2s', [5] = 'tr1'},
+    far = {[1] = 'br1', [2] = 'tr1', [3] = 'br2', [4] = 'tr2', [6] = 'tr3'},
+    distant = {[1] = 'tr2', [2] = 'br3', [4] = 'tr3'},
+    stress = {[1] = 'br1', [2] = 'tr1', [5] = 'br2'},
   },
   ['right_back'] = {
-    ['near'] = {[1] = 'k5', [3] = 'bl2s', [4] = 'tr1', [6] = 'tr2'},
-    ['far'] = {[1] = 'k5', [2] = 'bl2s', [5] = 'tr1'},
-    ['distant'] = {[1] = 'bl2s', [4] = 'tr1'},
-    ['stress'] = {[1] = 'br1', [3] = 'br2', [4] = 'tr1'},
+    near = {[1] = 'k5', [3] = 'bl2s', [5] = 'tr1'},
+    far = {[1] = 'bl2s', [3] = 'tr1', [6] = 'tr2'},
+    distant = {[1] = 'bl2s', [3] = 'tr2', [4] = 'tr3'},
+    stress = {[1] = 'br1', [2] = 'tr1', [6] = 'br2'},
   },
   ['back_right'] = {
-    ['near'] = {[1] = 'k5', [3] = 'bl2s', [5] = 'tr3'},
-    ['far'] = {[1] = 'k5', [3] = 'bl2s'},
-    ['distant'] = {[1] = 'bl2s', [4] = 'tr1'},
-    ['stress'] = {[1] = 'br1', [4] = 'tr1'},
+    near = {[1] = 'k5', [3] = 'br2s', [4] = 'bl2s', [6] = 'tr3'},
+    far = {[1] = 'k5', [2] = 'bl2s', [4] = 'tr2', [5] = 'tr3'},
+    distant = {[1] = 'k5', [2] = 'bl2s', [4] = 'tr1'},
+    stress = {[1] = 'br1', [2] = 'tr1', [6] = 'br2'},
   },
 }
 BehaviourDB.rule_sets[1].ships['tiebainterceptor'].action_selection = {


### PR DESCRIPTION
Move Improvements
Scum: Cust YT-1300, Aggressor, Escape Craft, G-1A, Lancer, Kimogila, Scurrg, YV-666, Jumpmaster, Quadjumper
FO: TIE/se, TIE/vn, TIE/wi, Upsilon, Xi, TIE/ba