### PR TITLE
StarForge Script Manager Take Out and Put Away Functionality

### DIFF
--- a/TTS_xwing/src/Game/StarForge/StarForge.ttslua
+++ b/TTS_xwing/src/Game/StarForge/StarForge.ttslua
@@ -71,7 +71,15 @@ local StarForge = {
 
 local SFScript = require("TTS_xwing.src.Game.StarForge.StarForgeScriptManager")
 
-function onLoad(save_data)
+function onSave()
+    local saveData = JSON.encode(SFScript.objects)
+    return saveData
+end
+
+function onLoad(saveData)
+    if saveData ~= "" then
+        SFScript.objects = JSON.decode(saveData)
+    end
     -- self.setLock(true)
     -- self.unregisterCollisions()
     addContextMenus()
@@ -80,7 +88,6 @@ end
 function addContextMenus()
     self.addContextMenuItem("Multi-State Object", MultiStateExp)
     self.addContextMenuItem("List Factories", ListFactories)
-    self.addContextMenuItem("Find Duplicates", FindDuplicates)
     self.addContextMenuItem("Extract All Products", SFScript.ExtractAllProducts)
     self.addContextMenuItem("Put Everything Away", SFScript.PutEverythingAway)
     self.addContextMenuItem("Dump Products", SFScript.dumpProducts)
@@ -89,7 +96,6 @@ end
 local function colorText(text, color)
     return "[" .. color:toHex() .. "]" .. text .. "[-]"
 end
-
 
 MultiStateExp = function()
     -- local bag = getObjectFromGUID("224816") -- Charge Token
@@ -119,30 +125,6 @@ ListFactories = function()
     end
     printToAll("End Factories:")
 end
-
-FindDuplicates = function()
-    printToAll("Find Duplicates")
-    local everything = getObjects()
-    for _, object in ipairs(everything) do
-        local product = object.getName()
-        local objType = object.type
-        if objType == "Infinite" then
-            local products = takeAlook(object)
-            -- local factory = factory(object, printInfiniteBag, 'printInfiniteBag')
-            printToAll("InfiniteBag: " .. object.getName)
-            table.print(products, object.getName())
-        end
-        if objType == "Bag" then
-            local products = watchaGot(object)
-            -- local factory = factory(object, printBag, 'printBag')
-            -- StarForge.factories[product] = factory
-            printToAll("Bag: " .. object.getName)
-            table.print(products, object.getName())
-        end
-    end
-    printToAll("Update Factories Done")
-end
-
 
 StarForge.RegisterFactory = function(factory, product)
     local previousFactory = StarForge.factories[product]

--- a/TTS_xwing/src/Game/StarForge/StarForgeLayout.ttslua
+++ b/TTS_xwing/src/Game/StarForge/StarForgeLayout.ttslua
@@ -1,0 +1,33 @@
+-- StarForgeLayout.ttslua
+
+StarForgeLayout = {
+    epic = { x = -35, y = 2, z = -14 },
+    start = { x = -35, y = 2, z = -14 },
+    position = { x = 0, y = 0, z = 0 },
+    count = 0,
+    
+    -- Calculate the next position based on count
+    nextPosition = function(self)
+        self.count = self.count + 1
+        self.position = {
+            x = self.start.x + math.floor(self.count / 10) * 3.5,
+            y = self.start.y,
+            z = self.start.z + (self.count % 10) * 3
+        }
+        return self.position
+    end
+}
+
+function printActiveLayout()
+    -- TODO: should be able to use this to determine which Layout the table is in.
+    local layoutControllerGUID = "b3992e"
+    local layoutController = getObjectFromGUID(layoutControllerGUID)
+    if layoutController then
+        local activeLayoutIndex = layoutController.call("getActiveLayoutIndex")
+        print("Current active layout index is:", activeLayoutIndex)
+    else
+        print("Layout Controller not found")
+    end
+end
+
+return StarForgeLayout

--- a/TTS_xwing/src/Game/StarForge/StarForgeScriptManager.ttslua
+++ b/TTS_xwing/src/Game/StarForge/StarForgeScriptManager.ttslua
@@ -49,7 +49,7 @@ Utility Object to aid in Game Mod Script Updates. Locating and "sourcing" Object
 local StarForgeScriptManager = {
     objects = {},
 
-    -- Define a function to add an object to the manager
+    -- Add an object to the manager
     addObject = function(self, bag, object)
         local entry = {
             guid = object.getGUID(),
@@ -57,11 +57,12 @@ local StarForgeScriptManager = {
             bagGUID = bag.getGUID(),
             stateId = object.getStateId(),
             states = {},  -- Table to hold states if it's a multi-state object
-            istates = {}, -- Table to hold states if it's a multi-state object
         }
 
         self.objects[object.getGUID()] = entry
     end,
+
+    -- Add a state to an existing multi-state object
     addState = function(self, multiObject, stateClone)
         if multiObject == stateClone then
             return
@@ -75,23 +76,7 @@ local StarForgeScriptManager = {
     end
 }
 
-local Layout = {
-    epic = { x = -35, y = 2, z = -14 },
-    start = { x = -35, y = 2, z = -14 },
-    position = { x = 0, y = 0, z = 0 },
-    count = 0,
-
-    -- Function to calculate the next position based on count
-    nextPosition = function(self)
-        self.count = self.count + 1
-        self.position = {
-            x = self.start.x + math.floor(self.count / 10) * 3.5,
-            y = self.start.y,
-            z = self.start.z + (self.count % 10) * 3
-        }
-        return self.position
-    end
-}
+local Layout = require("TTS_xwing.src.Game.StarForge.StarForgeLayout")
 
 local layoutInfiniteBag = function(infiniteBag)
     StarForgeScriptManager.takeObject(infiniteBag, "")
@@ -121,8 +106,7 @@ StarForgeScriptManager.ExtractAllProducts = function()
     for _, object in ipairs(everything) do
         if object.type == "Infinite" then
             layoutInfiniteBag(object)
-        end
-        if object.type == "Bag" then
+        elseif object.type == "Bag" then
             layoutMixedBag(object)
         end
     end
@@ -207,8 +191,8 @@ function copyStateScript(index, entry, multiObject, callback)
         return copyStateScript(index - 1, entry, multiObject, callback)
     end, function()
         local isMultiObjectReady = multiObject ~= nil and not multiObject.spawning
-        local isstateReady = stateCopy ~= nil and not stateCopy.spawning
-        return isMultiObjectReady and isstateReady
+        local isStateReady = stateCopy ~= nil and not stateCopy.spawning
+        return isMultiObjectReady and isStateReady
     end)
 end
 


### PR DESCRIPTION
## Star Forge

Utility Object to aid in Game Mod Script Updates. This StarForge feature helps with updating scripted objects, as well as multi-state scripted objects all at once.

- Go to Epic or HotAC Layout. Extract and lay out all scripted objects
    - Keeps track of where each object came from to survive a save and reload.
    - TODO: need a way to hide and put-away the Star Forge.

### Steps:

1. **Extract All Objects**:
    - Trigger a context menu to "Take Everything Out," which will:
    1. Lay out all scripted objects.
    2. Keep track of which Bag each object came from, as they need to be returned to their original bag.
    3. If the object is a multi-state object:
        - Keep track of the initial state (baseState).
        - Clone the object for each state and stack them vertically.
        - This allows VSCode to update the alternative state's scripts.

2. **Save and Reload**:
    1. Save the game via TTS UI.
    2. Load the game via TTS UI.
    3. Send all scripts from VSCode.

3. **Put Everything Away**:
    - Trigger a context menu to "Put Everything Away," which will:
    - For each object that was taken out:
        1. Reset the bag it came from.
        2. Put the object back.
        3. If the object is the initial state of a multi-state object:
            - Traverse all initial state's copies and have them:
                - Change the baseState object to match their state.
                - Set the baseState's script for that state to the new one from the extra state object.
                - Destroy the extra state object.
            - Set the initial state object back to its baseState.
        4. Put the initial state object back in the bag it came from.