### PR TITLE
Fix claimed objective visibility in top-down view

### DIFF
--- a/TTS_xwing/src/Marker/Scenario/Objective.lua
+++ b/TTS_xwing/src/Marker/Scenario/Objective.lua
@@ -16,11 +16,13 @@ Data = { Size = "objective" }
 function claim(player)
     local color = Color.fromString(player)
     self.setColorTint(color)
+    self.highlightOn(color)
     printToAll(player .. " claimed an objective", Color(1.0, 1.0, 0))
 end
 
 function unclaim(player)
     self.setColorTint(Color(1, 1, 1, 0.00))
+    self.highlightOff()
     printToAll(player .. " removed claim of an objective", Color(1.0, 1.0, 0))
 end
 


### PR DESCRIPTION
## Summary

- Claimed objectives are invisible when using the overhead/top-down camera because `setColorTint` only tints the material, which isn't visible from directly above
- Added `highlightOn(color)` on claim and `highlightOff()` on unclaim — the highlight outline renders from every camera angle

## Video

https://github.com/user-attachments/assets/bd6ac62a-1b96-4394-ae16-05a916774dfe

## Files changed

- `TTS_xwing/src/Marker/Scenario/Objective.lua` — added `highlightOn`/`highlightOff` calls in claim/unclaim functions

## Test plan

- [ ] Claim an objective as Red — verify red outline visible from all angles including top-down
- [ ] Claim an objective as Blue — verify blue outline
- [ ] Remove claim — verify outline disappears
- [ ] Verify no impact on existing setColorTint behavior at normal camera angles