### PR TITLE
Fix turret for original Horton Salm (pilot 15)

### DIFF
--- a/TTS_xwing/src/Game/Component/Spawner/PilotDb.lua
+++ b/TTS_xwing/src/Game/Component/Spawner/PilotDb.lua
@@ -360,7 +360,8 @@ masterPilotDB[15] = {
     slot = { 21, 1, 4, 5, 6, 10, 12, 14 },
     init = 4,
     texture = 'horton',
-    actSet = { 'F', 'TL', 'BR' }
+    actSet = { 'F', 'TL', 'BR' },
+    arcs = { fixed = { range = 3, type = { 'front' } }, turret = { main = { name = 'ion cannon turret', range = 2, type = { 'singleturret' } } } }
 }
 
 masterPilotDB[16] = {


### PR DESCRIPTION
## Summary

Original Horton Salm (pilot 15, XWS: `hortonsalm`) is missing the `arcs.turret` table, preventing turret attachment. Same issue that was fixed for SSB Horton (pilot 1036) in 9484da56.

Related fix: https://github.com/JohnnyCheese/TTS_X-Wing2.0/commit/9484da56

## Change

Added `arcs` table with `turret.main` definition matching the Ion Cannon Turret configuration.

## Test plan

- [ ] Spawn original Horton Salm (non-SL version)
- [ ] Attach Ion Cannon Turret — verify it attaches successfully
- [ ] Verify turret arc indicator displays correctly