### PR TITLE
Fix condition tokens not following assigned ships

### DIFF
--- a/TTS_xwing/src/Global.lua
+++ b/TTS_xwing/src/Global.lua
@@ -6117,6 +6117,7 @@ function newSpawner(listTable)
                             newAsset = tempBagAcc.takeObject({ position = pos, rotation = rot, guid = acc.guid, smooth = false })
                             assetClone = newAsset.clone()
                             assetClone.setPosition(pos)
+                            assetClone.addTag("Assignable")
                             tempBagAcc.putObject(newAsset)
                         end
                     end
@@ -6245,6 +6246,7 @@ function newSpawner(listTable)
                         newAsset = tempBagAcc.takeObject({ position = pos, rotation = rot, guid = acc.guid })
                         assetClone = newAsset.clone()
                         assetClone.setPosition(pos)
+                        assetClone.addTag("Assignable")
                         tempBagAcc.putObject(newAsset)
                     end
                 end


### PR DESCRIPTION
## Summary

Condition cards (e.g. Merciless Pursuit from The Child) spawned from upgrades or pilots are not tagged as `Assignable`. The token system requires this tag to recognize objects dropped near ships and track them during movement. Without it, condition tokens sit static on the table after being placed on an enemy ship.

## Change

Added `assetClone.addTag("Assignable")` in both condition spawn paths:
- Upgrade conditions (`Up.Condition`)
- Pilot conditions (`Pilots[shipIndex].Condition`)

## Test plan

- [ ] Spawn a list with The Child upgrade (Merciless Pursuit condition)
- [ ] Drop the Merciless Pursuit card near an enemy ship
- [ ] Verify "Assigned to [ship]" message appears in chat
- [ ] Move the ship — verify the condition card follows it
- [ ] Remove the condition — verify it unassigns cleanly