### PR TITLE
Add boost action to SL Deathfire (Swift Approach)

### DIFF
--- a/TTS_xwing/src/Game/Component/Spawner/PilotDb.lua
+++ b/TTS_xwing/src/Game/Component/Spawner/PilotDb.lua
@@ -9012,7 +9012,7 @@ masterPilotDB[1047] = {
     Charge = 2,
     init = 2,
     texture = 'grey',
-    actSet = { 'F', 'TL', 'BR' },
+    actSet = { 'F', 'TL', 'BR', 'B' },
     standardized_loadout = true,
     standardized_upgrades = {
         { name = 'Swift Approach', charge = 0 },


### PR DESCRIPTION
## Summary
- Adds 'B' (boost) to Deathfire's SL actSet — Swift Approach grants boost but it was missing from the action wheel
- Captain Jonus Top Cover bomb launch templates (be3r, s3r, br3r) were already merged in 28396766

## Test plan
- Spawn SL Deathfire (Swift Approach) from a list
- Press R to open action wheel — boost should now appear alongside barrel roll
- Verify other Deathfire variants are unaffected