### PR TITLE
Add 3 shields to SL Klick (Siege of Coruscant)

### DIFF
--- a/TTS_xwing/src/Game/Component/Spawner/PilotDb.lua
+++ b/TTS_xwing/src/Game/Component/Spawner/PilotDb.lua
@@ -8698,6 +8698,7 @@ masterPilotDB[1031] = {
     texture = 'red',
     actSet = { 'F', 'TL', 'BR', 'B' },
     keywords = { 'Clone' },
+    Shield = 3,
     standardized_loadout = true,
     executeOptions = {
         rk2 = { [1] = 'rk2', [2] = 'rbl2s', [3] = 'rbr2s' },


### PR DESCRIPTION
## Summary
- SL Klick (Siege of Coruscant) was missing `Shield = 3` in the pilot database, so no shield tokens spawned with the ship

## Test plan
- Spawn SL Klick (Siege of Coruscant) from a list
- Verify 3 shield tokens spawn with the ship