### PR TITLE
Fix CIS Boba Fett XWS, cost, and card image

### DIFF
--- a/TTS_xwing/src/Game/Component/Spawner/DataPad.lua
+++ b/TTS_xwing/src/Game/Component/Spawner/DataPad.lua
@@ -1079,7 +1079,7 @@ function idSpawner(idTable)
         --fList.Pilots[k].card = masterPilotDB[v].card
         fList.Pilots[k].card = "{verifycache}https://raw.githubusercontent.com/" ..
             repo .. "/x-wing2.0-project-goldenrod/" ..
-            Format .. "/src/images/En/pilots/" .. masterPilotDB[v].XWS .. ".png"
+            Format .. "/src/images/En/pilots/" .. (masterPilotDB[v].imageXWS or masterPilotDB[v].XWS) .. ".png"
         fList.Pilots[k].cardB = cardBackDB[ffgFaction[fList.Faction]]
         fList.Pilots[k].standardized_loadout = masterPilotDB[v].standardized_loadout
         fList.Pilots[k].standardized_upgrades = masterPilotDB[v].standardized_upgrades

--- a/TTS_xwing/src/Game/Component/Spawner/PilotDb.lua
+++ b/TTS_xwing/src/Game/Component/Spawner/PilotDb.lua
@@ -6298,12 +6298,13 @@ masterPilotDB[801] = {
 
 masterPilotDB[802] = {
     name = 'Boba Fett',
-    XWS = 'bobafett-separatistalliance',
+    XWS = 'bobafett-firesprayclasspatrolcraft',
+    imageXWS = 'bobafett-separatistalliance',
     title = 'Survivor',
     limited = 1,
     Faction = 7,
     ship_type = 'firesprayclasspatrolcraft',
-    cost = 70,
+    cost = 64,
     slot = { 21, 3, 6, 8, 12, 13, 14, 15 },
     init = 3,
     texture = 'jango',

--- a/TTS_xwing/src/Game/Mechanic/Movement/ManeuverCard.lua
+++ b/TTS_xwing/src/Game/Mechanic/Movement/ManeuverCard.lua
@@ -66,7 +66,7 @@ function assignShip(ship)
     local cardImage = backImage
     for key,pilot in pairs(pilotDB) do
         if pilot.ship_type == shipData.shipId and pilot.Faction == shipData['Faction'] then
-            cardImage = "https://raw.githubusercontent.com/eirikmun/x-wing2.0-project-goldenrod/2.5/src/images/En/pilots/" .. pilot.XWS .. ".png"
+            cardImage = "https://raw.githubusercontent.com/eirikmun/x-wing2.0-project-goldenrod/2.5/src/images/En/pilots/" .. (pilot.imageXWS or pilot.XWS) .. ".png"
             break
         end
     end


### PR DESCRIPTION
## Summary
- Fix CIS Boba Fett XWS from `bobafett-separatistalliance` to `bobafett-firesprayclasspatrolcraft` to match YASB exports so he spawns from imported lists
- Fix cost from 70 to 64
- Add `imageXWS` field support so the card image URL can use a different name than the XWS (the goldenrod image repo has it under the old name)

## Test plan
- Import a YASB list with CIS Boba Fett — should now spawn correctly
- Verify the pilot card image loads without errors
- Verify Scum Boba Fett is unaffected