### PR TITLE
Add port/starboard sideways bomb drops for BoE B-Wings

### DIFF
--- a/TTS_xwing/src/Device/Bomb/DropperGizmo.lua
+++ b/TTS_xwing/src/Device/Bomb/DropperGizmo.lua
@@ -95,11 +95,23 @@ butPos['br3'] = { 1 * sp, 3 * sp }
 butPos['tr1'] = { 2 * sp, 1 * sp }
 butPos['tr2'] = { 2 * sp, 2 * sp }
 butPos['tr3'] = { 2 * sp, 3 * sp }
+-- Port/starboard (sideways) drop positions
+butPos['ss1'] = { 3 * sp, 0 }
+butPos['ss2'] = { 3 * sp, 1 * sp }
+butPos['ps1'] = { -3 * sp, 0 }
+butPos['ps2'] = { -3 * sp, 1 * sp }
 
 -- Get a drop buttons position (left/front variant included)
 function ButtonPos(butCode)
     local rev = false
     local left = false
+    -- Port/starboard codes (ss1, ps1, etc.) are looked up directly
+    if butCode:sub(1, 2) == 'ss' or butCode:sub(1, 2) == 'ps' then
+        local height = 0.3
+        local src = butPos[butCode]
+        if src == nil then return nil end
+        return { src[1], height, src[2] }
+    end
     if butCode:sub(-1, -1) == 'r' then
         rev = true
         butCode = butCode:sub(1, -2)

--- a/TTS_xwing/src/Game/Component/Spawner/DataPad.lua
+++ b/TTS_xwing/src/Game/Component/Spawner/DataPad.lua
@@ -1127,8 +1127,10 @@ function idSpawner(idTable)
             fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':s3:tr3:te3'
         elseif v == 205 then               -- Sol Sixxa special drops
             fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':te1:be1:br1:tr1'
-        elseif v == 1068 or v == 1075 then -- Partin gift upgrade special drop
+        elseif v == 1068 then              -- Parting Gift upgrade special drop
             fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':s1r:br1r:bl1r'
+        elseif v == 1075 then              -- Adon Fox BoE (Parting Gift + sideways)
+            fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':s1r:br1r:bl1r:ss1:ps1'
         elseif v == 161 then               -- Constable Zuvio
             fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':s1r'
         elseif v == 565 then               -- Bombardment Drone
@@ -1137,8 +1139,10 @@ function idSpawner(idTable)
             fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':be3:br3:s3:s3r'
         elseif v == 10022 then
             fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':be1:br1:s2:be2:br2'
-        elseif v == 1048 then 
+        elseif v == 1048 then
             fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':s3r:be3r:br3r'
+        elseif v == 1074 or v == 1076 then -- BoE B-Wings sideways drops
+            fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':ss1:ps1'
         end
 
         if Ship == 'tiesabomber' then -- TIE Bomber special drops

--- a/TTS_xwing/src/Game/Component/Spawner/DataPad.lua
+++ b/TTS_xwing/src/Game/Component/Spawner/DataPad.lua
@@ -1130,7 +1130,7 @@ function idSpawner(idTable)
         elseif v == 1068 then              -- Parting Gift upgrade special drop
             fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':s1r:br1r:bl1r'
         elseif v == 1075 then              -- Adon Fox BoE (Parting Gift + sideways)
-            fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':s1r:br1r:bl1r:ss1:ps1'
+            fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':s1r:br1r:bl1r:be1:br1:ss1:ps1'
         elseif v == 161 then               -- Constable Zuvio
             fList.Pilots[k].bombD = fList.Pilots[k].bombD .. ':s1r'
         elseif v == 565 then               -- Bombardment Drone

--- a/TTS_xwing/src/Global.lua
+++ b/TTS_xwing/src/Global.lua
@@ -4692,6 +4692,31 @@ DialModule.PlaceTemplate = function(ship, speed, type, position, dir, extra)
     return newTemplate
 end
 
+-- Spawn a template rotated sideways for port/starboard bomb drops
+-- rotAngle: -90 for starboard (right), 90 for port (left)
+DialModule.SpawnSideTemplate = function(ship, speed, rotAngle)
+    if speed == 0 then return nil end
+    local baseSize = ship.getTable("Data").Size or 'small'
+    local sideOffset = DialModule.TemplateData.baseOffset[baseSize][3]
+    local templateLen = DialModule.TemplateData.straight[speed][3]
+    local xOffset = sideOffset + templateLen
+    local yOffset = DialModule.TemplateData.straight[speed][2]
+    local entry
+    if rotAngle < 0 then
+        entry = { xOffset, yOffset, 0, rotAngle }
+    else
+        entry = { -xOffset, yOffset, 0, rotAngle }
+    end
+    local finPos = MoveModule.EntryToPos(entry, ship)
+    local src = TokenModule.tokenSources['s' .. speed]
+    local newTemplate = src.takeObject({ position = finPos.pos, rotation = finPos.rot })
+    newTemplate.lock()
+    newTemplate.setPosition(finPos.pos)
+    newTemplate.setRotation(finPos.rot)
+    table.insert(DialModule.SpawnedTemplates, { template = newTemplate, ship = ship })
+    return newTemplate
+end
+
 -- Delete template spawned for a ship, return true if deleted, false if there was none
 DialModule.DeleteTemplate = function(ship)
     for k, info in pairs(DialModule.SpawnedTemplates) do
@@ -5291,6 +5316,7 @@ BombModule.dropTable = {}
 XW_cmd.AddCommand('b:s[1-5][r]?', 'bombDrop')
 XW_cmd.AddCommand('b:b[rle][1-3][r]?', 'bombDrop')
 XW_cmd.AddCommand('b:t[rle][1-3][r]?', 'bombDrop')
+XW_cmd.AddCommand('b:[ps]s[1-3]', 'bombDrop')
 
 -- Spawn a bomb drop, delete old ones
 -- If that exact one existed, just delete
@@ -5307,7 +5333,27 @@ BombModule.SpawnDrop = function(ship, dropCode)
     DialModule.DeleteTemplate(ship)
     local dropPos = nil
     local temp = nil
-    if dropCode:sub(-1, -1) == 'r' then
+    -- PORT/STARBOARD sideways drops (ps1, ss1, etc.)
+    local sideDir = templateCode:sub(1, 2)
+    if sideDir == 'ss' or sideDir == 'ps' then
+        local speed = tonumber(templateCode:sub(3, 3))
+        local rotAngle = (sideDir == 'ss') and -90 or 90
+        temp = DialModule.SpawnSideTemplate(ship, speed, rotAngle)
+        if temp ~= nil then
+            temp.createButton(BombModule.deleteButton)
+            -- Get template position and offset to the far end (away from ship)
+            local tempPos = temp.getPosition()
+            local tempRot = temp.getRotation()
+            local templateLen = Dim.Convert_mm_igu(35)
+            local rad = math.rad(tempRot[2])
+            local farEnd = {
+                tempPos[1] + templateLen * math.sin(rad),
+                tempPos[2],
+                tempPos[3] + templateLen * math.cos(rad)
+            }
+            dropPos = { finPos = { pos = farEnd, rot = { tempRot[1], tempRot[2], tempRot[3] } } }
+        end
+    elseif dropCode:sub(-1, -1) == 'r' then
         -- FRONT drops
         temp = DialModule.SpawnTemplate(ship, templateCode:sub(1, -2) .. '_B')
         temp.createButton(BombModule.deleteButton)
@@ -5398,13 +5444,19 @@ BombModule.OnTokenDrop = function(token)
     if closest.pointKey ~= nil then
         -- Move the token to the snap points
         local drop = BombModule.dropTable[closest.pointKey]
-        local destPos = Vect.Sum(drop.dest.pos, Vect.RotateDeg(offset.pos, drop.dest.rot[2]))
-
-        local size = drop.ship.getTable("Data").Size or 'small'
-        if size == 'large' then
-            destPos = Vect.Sum(destPos, Vect.RotateDeg({ 0, 0, Dim.Convert_mm_igu(-20) }, drop.dest.rot[2]))
-        elseif size == 'medium' then
-            destPos = Vect.Sum(destPos, Vect.RotateDeg({ 0, 0, Dim.Convert_mm_igu(-10) }, drop.dest.rot[2]))
+        local isSideDrop = drop.code and (drop.code:find(':ss') or drop.code:find(':ps'))
+        local destPos
+        if isSideDrop then
+            -- Sideways drops: place bomb directly at the drop point
+            destPos = { drop.dest.pos[1], drop.dest.pos[2], drop.dest.pos[3] }
+        else
+            destPos = Vect.Sum(drop.dest.pos, Vect.RotateDeg(offset.pos, drop.dest.rot[2]))
+            local size = drop.ship.getTable("Data").Size or 'small'
+            if size == 'large' then
+                destPos = Vect.Sum(destPos, Vect.RotateDeg({ 0, 0, Dim.Convert_mm_igu(-20) }, drop.dest.rot[2]))
+            elseif size == 'medium' then
+                destPos = Vect.Sum(destPos, Vect.RotateDeg({ 0, 0, Dim.Convert_mm_igu(-10) }, drop.dest.rot[2]))
+            end
         end
         local destRot = Vect.Sum(drop.dest.rot, offset.rot)
         destPos[2] = drop.ship.getPosition()[2] + offset.pos[2]


### PR DESCRIPTION
## Summary
- Adds sideways (port/starboard) bomb drop support using new drop codes `ss1`/`ps1` (starboard/port straight 1)
- New button positions on the bomb drop token for sideways drops
- `DialModule.SpawnSideTemplate` spawns a straight template rotated 90 degrees to the ship's side
- Sideways drops skip the normal bomb offset correction in `OnTokenDrop` to place bombs directly at the template endpoint
- Wired up for BoE B-Wings: Braylen Stramm (1074), Adon Fox (1075), Gina Moonsong (1076)
- Adon Fox gets both Parting Gift forward drops and sideways drops

## Test plan
- Spawn BoE Braylen Stramm from a list
- Click "Drop bomb" on the bomb drop token
- Verify `ss1` and `ps1` buttons appear on right and left sides
- Click `ss1` — straight template should appear to the right of the ship
- Drop a bomb on the template — it should snap to the far end
- Repeat for `ps1` (port/left side)
- Verify Adon Fox has both Parting Gift (s1r/br1r/bl1r) and sideways buttons
- Verify normal bomb drops on other ships are unaffected