### PR TITLE
Assign charge/shield tokens to objective markers

### DIFF
--- a/TTS_xwing/src/Global.lua
+++ b/TTS_xwing/src/Global.lua
@@ -3853,6 +3853,16 @@ TokenModule.onObjectDropped = function(player_color, object)
         return
     end
 
+    -- Check if a charge/shield token was dropped on an objective
+    local tokenType = object.getVar('__XW_TokenType')
+    if tokenType == 'Charge' or tokenType == 'Shield' then
+        local nearestObj = FindNearestObjective(object, 50)
+        if nearestObj ~= nil then
+            TokenModule.AssignTokenToObjective(object, nearestObj)
+            return
+        end
+    end
+
     local nearest = FindNearestShip(object, 100)
     TokenModule.AssignToken(object, nearest)
 end
@@ -7369,6 +7379,68 @@ function IsInFrontOfShip(object, ship)
 
     -- Check if the object is in front (dotProduct > 0) and within a reasonable margin
     return dotProduct > 0.01 -- Adjust the threshold for precision if needed
+end
+
+-- Find nearest objective marker within max_distance (in mm)
+function FindNearestObjective(object, max_distance)
+    local min_dist = Dim.Convert_mm_igu(max_distance or 50)
+    local objPos = object.getPosition():setAt('y', 0)
+    local nearest = nil
+    for _, obj in pairs(getObjects()) do
+        if obj.hasTag('Objective') then
+            local oPos = obj.getPosition():copy():setAt('y', 0)
+            local dist = oPos:distance(objPos)
+            if dist < min_dist then
+                nearest = obj
+                min_dist = dist
+            end
+        end
+    end
+    return nearest
+end
+
+-- Assign a charge/shield token to an objective: snap to center, lock, add click-to-spend button
+TokenModule.AssignTokenToObjective = function(token, objective)
+    local objPos = objective.getPosition()
+    local objRot = objective.getRotation()
+    local destPos = { objPos[1], objPos[2] + 0.3, objPos[3] }
+    token.setPositionSmooth(destPos, false, true)
+    token.setRotationSmooth({ 0, objRot[2], 0 }, false, true)
+    Wait.time(function()
+        token.lock()
+        token.clearButtons()
+        token.createButton({
+            click_function = 'ObjectiveChargeToggle',
+            function_owner = Global,
+            label = '',
+            position = { 0, 0.2, 0 },
+            width = 600,
+            height = 600,
+            font_size = 1,
+            color = { 1, 1, 1, 0 },
+            tooltip = 'Click to spend/recover'
+        })
+    end, 0.5)
+    TokenModule.tokenAssignments[token.getGUID()] = objective
+    token.setDescription("Assigned to objective")
+    token.setVar("charge_owner", "Objective")
+    TokenModule.objectiveTokens = TokenModule.objectiveTokens or {}
+    TokenModule.objectiveTokens[token.getGUID()] = { token = token, objective = objective, spent = false }
+end
+
+function ObjectiveChargeToggle(obj, player_color)
+    if TokenModule.objectiveTokens == nil then return end
+    local entry = TokenModule.objectiveTokens[obj.getGUID()]
+    if entry then
+        entry.spent = not entry.spent
+        if entry.spent then
+            obj.setColorTint({ 0.3, 0.3, 0.3 })
+            printToAll(Player[player_color].steam_name .. " spent an objective charge", { 1, 1, 0 })
+        else
+            obj.setColorTint({ 1, 1, 1 })
+            printToAll(Player[player_color].steam_name .. " recovered an objective charge", { 1, 1, 0 })
+        end
+    end
 end
 
 function FindNearestShip(object, max_distance, filter_function)


### PR DESCRIPTION
## Summary

**For Ancient Knowledge**

- Dropping a charge or shield token on an objective marker snaps it to the center and locks it
- Click the token to toggle spent/recovered (dims to dark grey when spent, restores to normal when recovered)
- Prints spend/recover messages to chat
- Only triggers for Charge and Shield token types within 50mm of an objective

## Test plan
- Place an objective marker on the table
- Drop a charge token near/on the objective
- Verify it snaps to center and locks
- Click the token — should dim and print "spent an objective charge"
- Click again — should restore and print "recovered an objective charge"
- Verify normal charge token assignment to ships still works