### PR TITLE
Rework objective charges into opt-in context menu

### DIFF
--- a/TTS_xwing/src/Global.lua
+++ b/TTS_xwing/src/Global.lua
@@ -3853,16 +3853,6 @@ TokenModule.onObjectDropped = function(player_color, object)
         return
     end
 
-    -- Check if a charge/shield token was dropped on an objective
-    local tokenType = object.getVar('__XW_TokenType')
-    if tokenType == 'Charge' or tokenType == 'Shield' then
-        local nearestObj = FindNearestObjective(object, 50)
-        if nearestObj ~= nil then
-            TokenModule.AssignTokenToObjective(object, nearestObj)
-            return
-        end
-    end
-
     local nearest = FindNearestShip(object, 100)
     TokenModule.AssignToken(object, nearest)
 end
@@ -7454,67 +7444,55 @@ function IsInFrontOfShip(object, ship)
     return dotProduct > 0.01 -- Adjust the threshold for precision if needed
 end
 
--- Find nearest objective marker within max_distance (in mm)
-function FindNearestObjective(object, max_distance)
-    local min_dist = Dim.Convert_mm_igu(max_distance or 50)
-    local objPos = object.getPosition():setAt('y', 0)
-    local nearest = nil
-    for _, obj in pairs(getObjects()) do
-        if obj.hasTag('Objective') then
-            local oPos = obj.getPosition():copy():setAt('y', 0)
-            local dist = oPos:distance(objPos)
-            if dist < min_dist then
-                nearest = obj
-                min_dist = dist
-            end
-        end
-    end
-    return nearest
-end
+-- GUID of the infinite Charge token bag.
+CHARGE_BAG_GUID = '224816'
 
--- Assign a charge/shield token to an objective: snap to center, lock, add click-to-spend button
-TokenModule.AssignTokenToObjective = function(token, objective)
+-- Map of charge-token GUID -> objective-marker GUID. Populated when a charge
+-- is enabled on an objective; read by the onObjectDropped handler below to
+-- snap the token back if the player moves it (so the token is flippable but
+-- effectively pinned to its objective).
+ObjectiveChargeTokens = ObjectiveChargeTokens or {}
+
+-- Spawn a charge token on an objective marker (context-menu opt-in).
+function ObjectiveSpawnCharge(params)
+    local objective = params.objective
+    if objective == nil then return nil end
+
+    local chargeBag = getObjectFromGUID(CHARGE_BAG_GUID)
+    if chargeBag == nil then return nil end
+
     local objPos = objective.getPosition()
     local objRot = objective.getRotation()
-    local destPos = { objPos[1], objPos[2] + 0.3, objPos[3] }
-    token.setPositionSmooth(destPos, false, true)
-    token.setRotationSmooth({ 0, objRot[2], 0 }, false, true)
-    Wait.time(function()
-        token.lock()
-        token.clearButtons()
-        token.createButton({
-            click_function = 'ObjectiveChargeToggle',
-            function_owner = Global,
-            label = '',
-            position = { 0, 0.2, 0 },
-            width = 600,
-            height = 600,
-            font_size = 1,
-            color = { 1, 1, 1, 0 },
-            tooltip = 'Click to spend/recover'
-        })
-    end, 0.5)
-    TokenModule.tokenAssignments[token.getGUID()] = objective
-    token.setDescription("Assigned to objective")
-    token.setVar("charge_owner", "Objective")
-    TokenModule.objectiveTokens = TokenModule.objectiveTokens or {}
-    TokenModule.objectiveTokens[token.getGUID()] = { token = token, objective = objective, spent = false }
+    local token = chargeBag.takeObject({
+        position = { objPos.x, objPos.y + 0.3, objPos.z },
+        rotation = { 0, objRot.y, 0 },
+        smooth = false
+    })
+
+    ObjectiveChargeTokens[token.getGUID()] = objective.getGUID()
+    return token.getGUID()
 end
 
-function ObjectiveChargeToggle(obj, player_color)
-    if TokenModule.objectiveTokens == nil then return end
-    local entry = TokenModule.objectiveTokens[obj.getGUID()]
-    if entry then
-        entry.spent = not entry.spent
-        if entry.spent then
-            obj.setColorTint({ 0.3, 0.3, 0.3 })
-            printToAll(Player[player_color].steam_name .. " spent an objective charge", { 1, 1, 0 })
-        else
-            obj.setColorTint({ 1, 1, 1 })
-            printToAll(Player[player_color].steam_name .. " recovered an objective charge", { 1, 1, 0 })
-        end
-    end
+-- Re-register on save/load so the snap-back map survives reloads.
+function ObjectiveRegisterCharge(params)
+    ObjectiveChargeTokens[params.tokenGuid] = params.objectiveGuid
 end
+
+function ObjectiveUnregisterCharge(params)
+    ObjectiveChargeTokens[params.tokenGuid] = nil
+end
+
+-- If the player drops a charge that belongs to an objective, snap it back.
+TokenModule.onObjectiveChargeDropped = function(player_color, object)
+    local objectiveGuid = ObjectiveChargeTokens[object.getGUID()]
+    if objectiveGuid == nil then return end
+    local objective = getObjectFromGUID(objectiveGuid)
+    if objective == nil then return end
+    local objPos = objective.getPosition()
+    object.setPositionSmooth({ objPos.x, objPos.y + 0.3, objPos.z }, false, true)
+end
+
+EventSub.Register('onObjectDropped', TokenModule.onObjectiveChargeDropped)
 
 function FindNearestShip(object, max_distance, filter_function)
     filter_function = filter_function or function(obj, ship) return true end

--- a/TTS_xwing/src/Marker/Scenario/MultiColorObjective.lua
+++ b/TTS_xwing/src/Marker/Scenario/MultiColorObjective.lua
@@ -7,6 +7,8 @@ waitDuration = 0.1
 
 boardLength = nil
 
+chargeTokenGuid = nil
+
 function claim(player)
     local color = Color.fromString(player)
     color[4] = 0.6
@@ -23,12 +25,17 @@ function onLoad(save_state)
     local state = JSON.decode(save_state)
     if state then
         lineDrawing = state.linedrawing or true
+        chargeTokenGuid = state.chargeTokenGuid
+    end
+    if chargeTokenGuid then
+        Global.call("ObjectiveRegisterCharge",
+            { tokenGuid = chargeTokenGuid, objectiveGuid = self.getGUID() })
     end
     SetupContextMenu()
 end
 
 function onSave()
-    return JSON.encode({ linedrawing = lineDrawing })
+    return JSON.encode({ linedrawing = lineDrawing, chargeTokenGuid = chargeTokenGuid })
 end
 
 function SetupContextMenu()
@@ -50,6 +57,29 @@ function SetupContextMenu()
             SetupContextMenu()
         end, false)
     end
+    if chargeTokenGuid and getObjectFromGUID(chargeTokenGuid) then
+        self.addContextMenuItem("Remove Charge", removeCharge, false)
+    else
+        self.addContextMenuItem("Enable Charge", enableCharge, false)
+    end
+end
+
+function enableCharge()
+    if chargeTokenGuid and getObjectFromGUID(chargeTokenGuid) then return end
+    chargeTokenGuid = Global.call("ObjectiveSpawnCharge", { objective = self })
+    SetupContextMenu()
+end
+
+function removeCharge()
+    if chargeTokenGuid then
+        Global.call("ObjectiveUnregisterCharge", { tokenGuid = chargeTokenGuid })
+        local token = getObjectFromGUID(chargeTokenGuid)
+        if token then
+            destroyObject(token)
+        end
+    end
+    chargeTokenGuid = nil
+    SetupContextMenu()
 end
 
 scale = 1 / self.getScale().x

--- a/TTS_xwing/src/Marker/Scenario/Objective.lua
+++ b/TTS_xwing/src/Marker/Scenario/Objective.lua
@@ -11,6 +11,8 @@ rulersType = nil
 
 boardLength = nil
 
+chargeTokenGuid = nil
+
 Data = { Size = "objective" }
 
 function claim(player)
@@ -30,12 +32,17 @@ function onLoad(save_state)
     local state = JSON.decode(save_state)
     if state then
         lineDrawing = state.linedrawing or true
+        chargeTokenGuid = state.chargeTokenGuid
+    end
+    if chargeTokenGuid then
+        Global.call("ObjectiveRegisterCharge",
+            { tokenGuid = chargeTokenGuid, objectiveGuid = self.getGUID() })
     end
     SetupContextMenu()
 end
 
 function onSave()
-    return JSON.encode({ linedrawing = lineDrawing })
+    return JSON.encode({ linedrawing = lineDrawing, chargeTokenGuid = chargeTokenGuid })
 end
 
 function SetupContextMenu()
@@ -57,6 +64,29 @@ function SetupContextMenu()
             SetupContextMenu()
         end, false)
     end
+    if chargeTokenGuid and getObjectFromGUID(chargeTokenGuid) then
+        self.addContextMenuItem("Remove Charge", removeCharge, false)
+    else
+        self.addContextMenuItem("Enable Charge", enableCharge, false)
+    end
+end
+
+function enableCharge()
+    if chargeTokenGuid and getObjectFromGUID(chargeTokenGuid) then return end
+    chargeTokenGuid = Global.call("ObjectiveSpawnCharge", { objective = self })
+    SetupContextMenu()
+end
+
+function removeCharge()
+    if chargeTokenGuid then
+        Global.call("ObjectiveUnregisterCharge", { tokenGuid = chargeTokenGuid })
+        local token = getObjectFromGUID(chargeTokenGuid)
+        if token then
+            destroyObject(token)
+        end
+    end
+    chargeTokenGuid = nil
+    SetupContextMenu()
 end
 
 function checkRange1()


### PR DESCRIPTION
## Summary

Follow-up to [#387](https://github.com/JohnnyCheese/TTS_X-Wing2.0/pull/387) addressing Flippster's review feedback. Replaces the drop-to-snap auto-assign with an explicit **Enable Charge** / **Remove Charge** right-click menu on each objective marker.

- **No more accidental drops onto objectives.** `TokenModule.onObjectDropped` no longer routes Charge/Shield tokens to objectives; only the marker's own menu spawns one.
- **Flippable, not dimmed.** The token is flipped (F key or scripted) to toggle spent/recovered — `Charge.lua:onFlip` already handles the chat messaging. The color-tint approach is gone.
- **Pinned via snap-back, not `setLock`.** Dragging the token triggers an `onObjectDropped` handler that returns it to the objective, so it stays put but flip still works.

Spawns from the infinite Charge token bag (`guid 224816`). The token GUID is persisted on the objective so the snap-back map survives save/load.

## Test plan

- [ ] Right-click an objective marker → **Enable Charge** → a charge token lands on it
- [ ] Press **F** while hovering the charge → flips face-down, `spent a charge token` prints
- [ ] Press **F** again → flips face-up, `recovered a charge token` prints
- [ ] Drag the charge away from the objective → snaps back
- [ ] Right-click objective → **Remove Charge** → token is destroyed, menu flips back to Enable
- [ ] Save & reload → Enable/Remove state persists, dragging still snaps back
- [ ] Normal charge-token assignment to ships still works (no regression from removing the drop branch)