### PR TITLE
Skip objective charges in TokenModule.ClearPosition

### DIFF
--- a/TTS_xwing/src/Global.lua
+++ b/TTS_xwing/src/Global.lua
@@ -4342,7 +4342,10 @@ TokenModule.ClearPosition = function(pos, dist, ignoreShip)
     local clearDist = dist + Dim.Convert_mm_igu(20)
     local posTokenInfo = TokenModule.GetNearTokensInfo(pos, clearDist)
     for k, tokenInfo in pairs(posTokenInfo) do
-        if tokenInfo.token.getButtons() == nil then
+        -- Leave objective charges alone; they're pinned to their objective.
+        if ObjectiveChargeTokens[tokenInfo.token.getGUID()] ~= nil then
+            -- skip
+        elseif tokenInfo.token.getButtons() == nil then
             if tokenInfo.owner ~= nil and tokenInfo.owner ~= ignoreShip then
                 local visPos = TokenModule.VisiblePosition(tokenInfo.token.getName(), tokenInfo.owner)
                 if Vect.Distance(visPos, pos) <= clearDist then


### PR DESCRIPTION
## Summary

Follow-up to [#388](https://github.com/JohnnyCheese/TTS_X-Wing2.0/pull/388) addressing Flippster's suggestion to add an `ObjectiveChargeTokens` lookup where we gather tokens affected by a move.

When a ship maneuvered through or into the objective's space, the charge was being yanked out by `TokenModule.ClearPosition`'s stray-token branch — the charge has no owner in `tokenAssignments`, so it fell through to the "shove away" path. `onObjectDropped` doesn't fire for scripted moves, so the snap-back handler in #388 couldn't catch it.

One-line skip at the top of the loop leaves objective charges pinned to their objective. Dragging the charge by hand still snaps back via the existing handler.

**Depends on #388** for the `ObjectiveChargeTokens` map.

## Test plan

- [ ] Enable a charge on an objective
- [ ] Fly a ship through/into the objective's area
- [ ] Verify the charge stays on the objective (not yanked out of the ship's path)
- [ ] Drag the charge by hand — still snaps back
- [ ] Verify normal stray-token clearing still works for non-objective-charge tokens