### PR TITLE
Add weapon arc visualizers for cannon upgrades

### DIFF
--- a/TTS_xwing/src/Game/Component/Spawner/DataPad.lua
+++ b/TTS_xwing/src/Game/Component/Spawner/DataPad.lua
@@ -1220,6 +1220,10 @@ function idSpawner(idTable)
             if masterUpgradesDB[value].arcs then
                 if masterUpgradesDB[value].arcs.fixed then
                     fList.Pilots[k].Data.arcs.fixed = fList.Pilots[k].Data.arcs.fixed or { name = 'primary', type = {} }
+                    if masterUpgradesDB[value].arcs.fixed.ion ~= nil then
+                        fList.Pilots[k].Data.arcs.fixed.ion = fList.Pilots[k].Data.arcs.fixed.ion or
+                            masterUpgradesDB[value].arcs.fixed.ion
+                    end
                     for new_arc_idx, new_arc in pairs(masterUpgradesDB[value].arcs.fixed.type) do
                         local found = false
                         for arc_idx, arc in pairs(fList.Pilots[k].Data.arcs.fixed.type) do
@@ -1250,6 +1254,14 @@ function idSpawner(idTable)
                         -- Add the turret to the available mounting point
                         fList.Pilots[k].Data.arcs.turret[mounting_point] = masterUpgradesDB[value].arcs.turret
                     end
+                end
+                if masterUpgradesDB[value].arcs.weapon then
+                    fList.Pilots[k].Data.arcs.weapon = fList.Pilots[k].Data.arcs.weapon or {}
+                    local weapon_arc = table.deepcopy(masterUpgradesDB[value].arcs.weapon)
+                    if weapon_arc.follow_turret == nil and masterShipDB[Ship].cannon_follow_turret then
+                        weapon_arc.follow_turret = masterShipDB[Ship].cannon_follow_turret
+                    end
+                    table.insert(fList.Pilots[k].Data.arcs.weapon, weapon_arc)
                 end
             end
             if masterUpgradesDB[value].Force ~= nil then

--- a/TTS_xwing/src/Game/Component/Spawner/PilotDb.lua
+++ b/TTS_xwing/src/Game/Component/Spawner/PilotDb.lua
@@ -6969,7 +6969,7 @@ masterPilotDB[964] = {
     init = 4,
     texture = 'gold',
     actSet = { 'F', 'TL', 'BR', 'B' },
-    arcs = { fixed = { range = 3, type = { 'front' } }, turret = { main = { name = 'ion cannon turret', range = 2, type = { 'singleturret' } } } },
+    arcs = { fixed = { range = 3, type = { 'front' } }, turret = { main = { name = 'ion cannon turret', range = 2, type = { 'singleturret' }, ion = true } } },
     standardized_loadout = true,
     standardized_upgrades = {
         { name = 'Ion Cannon Turret',     charge = 0 },
@@ -7195,7 +7195,7 @@ masterPilotDB[976] = {
     texture = 'gold',
     actSet = { 'F', 'TL', 'BR', 'B' },
     addSqdAction = { 'TL' },
-    arcs = { fixed = { range = 3, type = { 'front' } }, turret = { main = { name = 'ion cannon turret', range = 2, type = { 'singleturret' } } } },
+    arcs = { fixed = { range = 3, type = { 'front' } }, turret = { main = { name = 'ion cannon turret', range = 2, type = { 'singleturret' }, ion = true } } },
     standardized_loadout = true,
     standardized_upgrades = {
         { name = 'Ion Cannon Turret',     charge = 0 },
@@ -8151,7 +8151,7 @@ masterPilotDB[1035] = {
     texture = 'gold',
     actSet = { 'F', 'TL', 'BR', 'B' },
     addSqdAction = { 'TL' },
-    arcs = { fixed = { range = 3, type = { 'front' } }, turret = { main = { name = 'ion cannon turret', range = 2, type = { 'singleturret' } } } },
+    arcs = { fixed = { range = 3, type = { 'front' } }, turret = { main = { name = 'ion cannon turret', range = 2, type = { 'singleturret' }, ion = true } } },
     standardized_loadout = true,
     standardized_upgrades = {
         { name = 'Ion Cannon Turret', charge = 0 },
@@ -8169,7 +8169,7 @@ masterPilotDB[1036] = {
     init = 4,
     texture = 'horton',
     actSet = { 'F', 'TL', 'BR' },
-    arcs = { fixed = { range = 3, type = { 'front' } }, turret = { main = { name = 'ion cannon turret', range = 2, type = { 'singleturret' } } } },
+    arcs = { fixed = { range = 3, type = { 'front' } }, turret = { main = { name = 'ion cannon turret', range = 2, type = { 'singleturret' }, ion = true } } },
     standardized_loadout = true,
     standardized_upgrades = {
         { name = 'Ion Cannon Turret', charge = 0 },

--- a/TTS_xwing/src/Game/Component/Spawner/ShipDb.lua
+++ b/TTS_xwing/src/Game/Component/Spawner/ShipDb.lua
@@ -1986,6 +1986,7 @@ masterShipDB['tierbheavy'] = {
     },
     Fac = { [2] = true },
     arcs = { turret = { main = { name = 'primary', type = { 'front', 'back' } } } },
+    cannon_follow_turret = 'main',
     mesh =
     'https://raw.githubusercontent.com/JohnnyCheese/TTS_X-Wing2.0/master/assets/ships-v2/medium/tierbheavy/tieheavy.obj',
     moveSet = { 'rtl1', 'wbl1', 'bs1', 'wbr1', 'rtr1', 'wtl2', 'bbl2', 'bs2', 'bbr2', 'wtr2', 'rtl3t', 'rtl3', 'wbl3', 'ws3', 'wbr3', 'rtr3', 'rtr3t', 'ws4' },

--- a/TTS_xwing/src/Game/Component/Spawner/UpgradeDb.lua
+++ b/TTS_xwing/src/Game/Component/Spawner/UpgradeDb.lua
@@ -178,24 +178,53 @@ masterUpgradesDB['heavylasercannon'] = {
     name = 'Heavy Laser Cannon',
     XWS = 'heavylasercannon',
     slot = 3,
+    arcs = {
+        weapon = {
+            name = 'Heavy Laser Cannon',
+            range = 3,
+            type = { 'front' }
+        }
+    }
 }
 
 masterUpgradesDB['ioncannon'] = {
     name = 'Ion Cannon',
     XWS = 'ioncannon',
     slot = 3,
+    arcs = {
+        weapon = {
+            name = 'Ion Cannon',
+            range = 3,
+            type = { 'front' },
+            ion = true
+        }
+    }
 }
 
 masterUpgradesDB['jammingbeam'] = {
     name = 'Jamming Beam',
     XWS = 'jammingbeam',
     slot = 3,
+    arcs = {
+        weapon = {
+            name = 'Jamming Beam',
+            range = 3,
+            type = { 'front' }
+        }
+    }
 }
 
 masterUpgradesDB['tractorbeam'] = {
     name = 'Tractor Beam',
     XWS = 'tractorbeam',
     slot = 3,
+    arcs = {
+        weapon = {
+            name = 'Tractor Beam',
+            range = 3,
+            type = { 'front' }
+        }
+    }
 }
 
 
@@ -210,7 +239,7 @@ masterUpgradesDB['ioncannonturret'] = {
     name = 'Ion Cannon Turret',
     XWS = 'ioncannonturret',
     slot = 4,
-    arcs = { turret = { name = 'ion cannon turret', range = 2, type = { 'singleturret' } } }
+    arcs = { turret = { name = 'ion cannon turret', range = 2, type = { 'singleturret' }, ion = true } }
 }
 
 masterUpgradesDB['advprotontorpedoes'] = {
@@ -1766,6 +1795,13 @@ masterUpgradesDB['autoblasters'] = {
     name = "Autoblasters",
     XWS = 'autoblasters',
     slot = 3,
+    arcs = {
+        weapon = {
+            name = 'Autoblasters',
+            range = 1,
+            type = { 'front' }
+        }
+    }
 }
 
 masterUpgradesDB['plasmatorpedoes'] = {
@@ -2171,7 +2207,14 @@ masterUpgradesDB['syncedlasercannons'] = {
     slot = 3,
     remSlot = { 3 },
     cardB = cardBackDB['3b'],
-    restriction = {}
+    restriction = {},
+    arcs = {
+        weapon = {
+            name = 'Synced Laser Cannons',
+            range = 3,
+            type = { 'front' }
+        }
+    }
 }
 
 masterUpgradesDB['aaylasecura'] = {
@@ -2803,7 +2846,7 @@ masterUpgradesDB['ioncannonbattery'] = {
     cardB =
     'https://raw.githubusercontent.com/JohnnyCheese/TTS_X-Wing2.0/master/assets/textures/EpicCards/IonCannonBattery(Offline).png',
     restriction = {},
-    arcs = { turret = { name = 'ion cannon', range = 4, type = { 'singleturret' } } }
+    arcs = { turret = { name = 'ion cannon', range = 4, type = { 'singleturret' }, ion = true } }
 }
 
 masterUpgradesDB['targetingbattery'] = {
@@ -4340,7 +4383,14 @@ masterUpgradesDB['protoncannons'] = {
     slot = 3,
     remSlot = { 3 },
     cardB = cardBackDB['3b'],
-    Charge = 2
+    Charge = 2,
+    arcs = {
+        weapon = {
+            name = 'Proton Cannons',
+            range = 2,
+            type = { 'front' }
+        }
+    }
 }
 
 masterUpgradesDB['combatboardingtube'] = {

--- a/TTS_xwing/src/Game/VersionCheck.lua
+++ b/TTS_xwing/src/Game/VersionCheck.lua
@@ -1,4 +1,4 @@
-current_version = 115      -- mod version (workshop update count)
+current_version = 118      -- mod version (workshop update count)
 workshop_id = '2486128992' -- mod workshop ID
 
 -- To read above numbers, open your mod workshop page

--- a/TTS_xwing/src/Global.lua
+++ b/TTS_xwing/src/Global.lua
@@ -348,6 +348,8 @@ XW_cmd.Process = function(obj, cmd)
         DialModule.RotateArc(obj, cmd)
     elseif type == 'turretarc' then
         DialModule.TurretArc(obj, cmd)
+    elseif type == 'weaponarc' then
+        DialModule.WeaponArc(obj, cmd)
     elseif type == 'fixedarc' then
         DialModule.FixedArc(obj, cmd)
     elseif type == 'renameShip' then
@@ -4547,12 +4549,13 @@ DialModule.TurretArcCmd = {
 DialModule.TurretArc = function(ship, cmd)
     local arc = ship.call("GetTurretArc", DialModule.TurretArcCmd[cmd])
     local range = ship.call("GetTurretRange", DialModule.TurretArcCmd[cmd])
+    local turret_data = ship.getTable('Data').arcs.turret[DialModule.TurretArcCmd[cmd].mount]
     if arc then
         command = string.upper(arcToCmnd[arc])
         if range then
             command = command .. tostring(range)
         end
-        RulerModule.ToggleRuler(ship, command)
+        RulerModule.ToggleRuler(ship, command, false, turret_data and turret_data.ion)
     end
 end
 
@@ -4563,7 +4566,25 @@ DialModule.FixedArc = function(ship, cmd)
         if arc.range then
             command = command .. tostring(arc.range)
         end
-        RulerModule.ToggleRuler(ship, command)
+        RulerModule.ToggleRuler(ship, command, false, arc.ion)
+    end
+end
+
+DialModule.WeaponArc = function(ship, cmd)
+    local idx = tonumber(cmd:match("weapon(%d+)"))
+    if idx == nil then
+        return
+    end
+
+    local weapon = ship.call("GetWeaponData", { idx = idx })
+    local arc = ship.call("GetWeaponArc", { idx = idx })
+    local range = ship.call("GetWeaponRange", { idx = idx })
+    if weapon and arc then
+        command = string.upper(arcToCmnd[arc])
+        if range then
+            command = command .. tostring(range)
+        end
+        RulerModule.ToggleRuler(ship, command, false, weapon.ion)
     end
 end
 
@@ -5122,6 +5143,15 @@ RulerModule.typeToArc.LEFTRIGHT = 'leftright'
 RulerModule.typeToArc.BULL = 'bullseye'
 
 RulerModule.CachedRulers = {}
+RulerModule.defaultTint = color(1.0, 0.0, 0.0, 0.5)
+RulerModule.ionTint = color(0.2, 0.45, 1.0, 0.5)
+
+RulerModule.GetVisualizerTint = function(isIon)
+    if isIon then
+        return RulerModule.ionTint
+    end
+    return RulerModule.defaultTint
+end
 
 
 -- Get ruler spawn tables for some ship and some ruler code
@@ -5203,7 +5233,7 @@ end
 
 -- Spawn a ruler for a ship
 -- Returns new ruler reference
-RulerModule.SpawnRuler = function(ship, rulerType, beQuiet, include_friendly_ships, range)
+RulerModule.SpawnRuler = function(ship, rulerType, beQuiet, include_friendly_ships, range, isIon)
     local rulerData = RulerModule.CreateCustomTables(ship, rulerType, range)
     if rulerData.custom.mesh == nil then
         return nil
@@ -5220,11 +5250,12 @@ RulerModule.SpawnRuler = function(ship, rulerType, beQuiet, include_friendly_shi
         RulerModule.CachedRulers[rulerId].addTag('TempLayoutElement')
         RulerModule.CachedRulers[rulerId].interactable = false
         RulerModule.CachedRulers[rulerId].setLock(true)
-        RulerModule.CachedRulers[rulerId].setColorTint(color(1.0, 0.0, 0.0, 0.5))
+        RulerModule.CachedRulers[rulerId].setColorTint(RulerModule.defaultTint)
     end
     local newRuler = RulerModule.CachedRulers[rulerId].clone()
     newRuler.setPosition(ship.getPosition())
     newRuler.setRotation(rulerData.params.rotation)
+    newRuler.setColorTint(RulerModule.GetVisualizerTint(isIon))
 
     local arclines = {}
     if RulerModule.typeToArc[rulerType] then
@@ -5265,7 +5296,7 @@ end
 -- Toggle ruler for a ship
 -- If a ruler of queried type exists, just delete it and return nil
 -- If any other ruler exists, delete it (and spawn queried one), return new ruler ref
-RulerModule.ToggleRuler = function(ship, rulerType, beQuiet)
+RulerModule.ToggleRuler = function(ship, rulerType, beQuiet, isIon)
     local destType = RulerModule.DeleteRuler(ship)
 
     if destType ~= rulerType then
@@ -5293,7 +5324,7 @@ RulerModule.ToggleRuler = function(ship, rulerType, beQuiet)
         end
         ship.setLock(true)
         Wait.frames(function()
-            RulerModule.SpawnRuler(ship, spawnType, beQuiet, includeFriendlies, range)
+            RulerModule.SpawnRuler(ship, spawnType, beQuiet, includeFriendlies, range, isIon)
         end, 1)
     end
 end
@@ -5895,6 +5926,7 @@ end
 
 XW_cmd.AddCommand('rot[lr]?[12]?', 'rotate')
 XW_cmd.AddCommand('turret[12]?', 'turretarc')
+XW_cmd.AddCommand('weapon%d+', 'weaponarc')
 XW_cmd.AddCommand('a', 'fixedarc')
 
 mountRotations = {

--- a/TTS_xwing/src/Ship/CompositeBase.lua
+++ b/TTS_xwing/src/Ship/CompositeBase.lua
@@ -37,6 +37,11 @@ function initContextMenu()
                                 function(argument) self.setDescription('rotr' .. idx) end, false)
                         end
                     end
+                elseif type == 'weapon' then
+                    for idx, weapon in pairs(arc) do
+                        self.addContextMenuItem("FireArc - " .. weapon.name,
+                            function(argument) self.setDescription('weapon' .. tostring(idx)) end, false)
+                    end
                 end
             end
             local config = self.getTable("Data").Config
@@ -277,6 +282,37 @@ end
 function GetFixedArcs(args)
     local fixed = self.getTable("Data").arcs.fixed or {}
     return fixed.type or {}
+end
+
+function GetWeaponArc(args)
+    local idx = args.idx
+    local weapons = self.getTable("Data").arcs.weapon or {}
+    local weapon = weapons[idx]
+    if weapon == nil then
+        return nil
+    end
+
+    if weapon.follow_turret then
+        return GetTurretArc({ mount = weapon.follow_turret })
+    end
+
+    return (weapon.type or {})[1]
+end
+
+function GetWeaponRange(args)
+    local idx = args.idx
+    local weapons = self.getTable("Data").arcs.weapon or {}
+    local weapon = weapons[idx]
+    if weapon and weapon.range then
+        return weapon.range
+    end
+    return nil
+end
+
+function GetWeaponData(args)
+    local idx = args.idx
+    local weapons = self.getTable("Data").arcs.weapon or {}
+    return weapons[idx]
 end
 
 function GetAllTurretArcs(args)


### PR DESCRIPTION
## Summary
- add named weapon arc visualizers for cannon-slot upgrades
- tint ion weapon arc visualizers blue and preserve ion metadata on ion turrets
- make TIE/rb Heavy cannon arcs follow the ship turret mount and include the version bump

## Testing
- not run in TTS from this environment