### PR TITLE
Clean up leaked Charge/Force/Shield/Energy tokens on load

### DIFF
--- a/TTS_xwing/src/Global.lua
+++ b/TTS_xwing/src/Global.lua
@@ -7585,6 +7585,26 @@ function newSpawner(listTable)
     spawnCard.setRotation(storeRot)
 end
 
+-- newSpawner clones the Accessories bag at PosBag3 = { 15, 15, 0 } and pulls
+-- out Charge/Force/Shield/Energy as clone sources. They're normally destroyed
+-- at the end of newSpawner; if it errors mid-flow, the originals leak and end
+-- up persisted in saves. Clean up any stranded copies on load.
+local function cleanupLeakedSpawnerTokens()
+    local LEAK_NAMES = { Energy = true, Force = true, Shield = true, Charge = true }
+    for _, obj in pairs(getAllObjects()) do
+        if obj ~= nil and obj.tag ~= 'Infinite' and LEAK_NAMES[obj.getName() or ''] then
+            if obj.getDescription() == 'Unassigned' then
+                local pos = obj.getPosition()
+                local dx, dz = pos.x - 15, pos.z
+                if dx * dx + dz * dz <= 25 then
+                    obj.destruct()
+                end
+            end
+        end
+    end
+end
+EventSub.Register('onLoad', cleanupLeakedSpawnerTokens)
+
 function RotMatrix(axis, angDeg)
     local ang = math.rad(angDeg)
     local cs = math.cos


### PR DESCRIPTION
## Summary

On a fresh load of the published mod, four "Unassigned" tokens — one each of Energy, Force, Shield, and Charge — appear floating around `(x=17, z=0)` on the table. They have no connection to any ship and persist across saves.

## Root cause

`newSpawner` in `Global.lua` clones the Accessories bag at `PosBag3 = { 15, 15, 0 }` and extracts a Charge/Force/Shield/Energy token from it as the source for card-attached clones (lines 6720-6727). The originals are normally destroyed at the end of `newSpawner` (lines 7546-7550), but if anything errors mid-flow those four sources are left stranded at the bag-clone position. At some point during mod authoring this leaked into the published save state, so every fresh load surfaces them.

## Fix

Adds a defensive `onLoad` cleanup that destroys any non-Infinite Energy/Force/Shield/Charge object whose `Description == 'Unassigned'` and whose position is within 5 units of `(x=15, z=0)`. The legitimate Standard/Epic/HotAC layout positions for these tokens are all at small `x` (or `x ≈ 38` with the layout offset), so the fingerprint avoids false positives.

This fixes existing affected saves without requiring a re-publish.

## Test plan

- [x] Reproduced the four floating tokens on a fresh load from Workshop
- [x] Confirmed the four GUIDs match the spawner-leak fingerprint (`Description == 'Unassigned'`, clustered near `(x=17, z=0)`)
- [x] Verified the cleanup destroys exactly those four on next load
- [x] Verified the layout-tracked Infinite bags (07d45b/ebb247/717749/224816) are unaffected (skipped by `obj.tag ~= 'Infinite'`)